### PR TITLE
Bind viewModel to composable lifecycle

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.native.enableDependencyPropagation=false
 
 #Android
-android.compileSdk=31
+android.compileSdk=32
 android.targetSdk=31
 android.minSdk=21
 
@@ -20,3 +20,5 @@ version.appcompat=1.4.0
 version.material=1.4.0
 version.constraint=2.1.2
 version.lifecycleRuntimeKtx=2.4.0
+version.viewModelKtx=2.4.0
+version.composeViewModel=2.6.0-alpha01

--- a/modo-render-android-compose/build.gradle.kts
+++ b/modo-render-android-compose/build.gradle.kts
@@ -20,6 +20,7 @@ android {
 
     kotlinOptions {
         jvmTarget = "1.8"
+        freeCompilerArgs += "-Xjvm-default=all"
     }
 
     buildFeatures {
@@ -36,6 +37,8 @@ dependencies {
     implementation("androidx.compose.ui:ui:${properties["version.compose"]}")
     implementation("androidx.compose.foundation:foundation:${properties["version.compose"]}")
     implementation("org.jetbrains.kotlin:kotlin-parcelize-runtime:${properties["version.kotlin"]}")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:${properties["version.viewModelKtx"]}")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:${properties["version.composeViewModel"]}")
 }
 
 val sourceJar by tasks.registering(Jar::class) {

--- a/modo-render-android-compose/src/main/java/com/github/terrakok/modo/android/compose/ModoViewModel.kt
+++ b/modo-render-android-compose/src/main/java/com/github/terrakok/modo/android/compose/ModoViewModel.kt
@@ -1,0 +1,53 @@
+package com.github.terrakok.modo.android.compose
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.get
+
+internal class ModoViewModel : ViewModel() {
+
+    private val viewModelStores = mutableMapOf<String, ViewModelStore>()
+
+    fun clear(key: String) {
+        val viewModelStore = viewModelStores.remove(key)
+        viewModelStore?.clear()
+    }
+
+    override fun onCleared() {
+        viewModelStores.values.forEach { it.clear() }
+        viewModelStores.clear()
+    }
+
+    fun getViewModelStore(key: String): ViewModelStore {
+        var viewModelStore = viewModelStores[key]
+        if (viewModelStore == null) {
+            viewModelStore = ViewModelStore()
+            viewModelStores[key] = viewModelStore
+        }
+        return viewModelStore
+    }
+
+    override fun toString(): String {
+        val sb = StringBuilder("ViewModelStores (")
+        val viewModelStoreIterator: Iterator<String> = viewModelStores.keys.iterator()
+        while (viewModelStoreIterator.hasNext()) {
+            sb.append(viewModelStoreIterator.next())
+            if (viewModelStoreIterator.hasNext()) {
+                sb.append(", ")
+            }
+        }
+        sb.append(')')
+        return sb.toString()
+    }
+
+    companion object {
+        private val factory: ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>) = ModoViewModel() as T
+        }
+
+        fun getInstance(viewModelStore: ViewModelStore): ModoViewModel =
+            ViewModelProvider(viewModelStore, factory).get()
+    }
+}

--- a/sample-android-compose/build.gradle.kts
+++ b/sample-android-compose/build.gradle.kts
@@ -43,5 +43,6 @@ dependencies {
     implementation("androidx.compose.material:material:${properties["version.compose"]}")
     implementation("androidx.compose.ui:ui-tooling:${properties["version.compose"]}")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:${properties["version.lifecycleRuntimeKtx"]}")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:${properties["version.composeViewModel"]}")
     implementation("androidx.activity:activity-compose:${properties["version.composeActivity"]}")
 }

--- a/sample-android-compose/src/main/java/com/github/terrakok/androidcomposeapp/saveable/DetailsScreen.kt
+++ b/sample-android-compose/src/main/java/com/github/terrakok/androidcomposeapp/saveable/DetailsScreen.kt
@@ -1,14 +1,17 @@
 package com.github.terrakok.androidcomposeapp.saveable
 
+import android.util.Log
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.ViewModel
 import com.github.terrakok.modo.android.compose.ComposeScreen
 import com.github.terrakok.modo.android.compose.uniqueScreenKey
 import kotlinx.parcelize.Parcelize
+import androidx.lifecycle.viewmodel.compose.viewModel
 
 @Parcelize
 class DetailsScreen(
@@ -24,10 +27,25 @@ class DetailsScreen(
 }
 
 @Composable
-fun ProfileDetailsScreen(id: String) {
+fun ProfileDetailsScreen(
+    id: String,
+    viewModel: DetailsViewModel = viewModel()
+) {
     Box {
         Column(Modifier.align(Alignment.Center)) {
             Text(text = "Profile details $id")
         }
+    }
+}
+
+class DetailsViewModel : ViewModel() {
+
+    init {
+        Log.d(this.javaClass.name, "init")
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        Log.d(this.javaClass.name, "onCleared")
     }
 }


### PR DESCRIPTION
Create a viewModelStore for each screen
When you click on back button, viewModelStore of this screen cleans their viewModels
It's works for version 0.6.4

But now it doesn't work - your click on back button - viewModel cleared and right away viewModel is creating again.
If you delete content: RendererContent value when you create ComposeRenderImpl in AppActivity and will use defaultRendererContent - it works good
I think we have a problem with content: RendererContent implementation

`ScreenTransition(
            transitionSpec = {
                if (transitionType == ScreenTransitionType.Replace) {
                    scaleIn(initialScale = 2f) + fadeIn() with fadeOut()
                } else {
                    val (initialOffset, targetOffset) = when (transitionType) {
                        ScreenTransitionType.Pop -> ({ size: Int -> -size }) to ({ size: Int -> size })
                        else -> ({ size: Int -> size }) to ({ size: Int -> -size })
                    }
                    slideInHorizontally(initialOffsetX = initialOffset) with
                            slideOutHorizontally(targetOffsetX = targetOffset)
                }
            }
        )`