### PR TITLE
Fix clearing ScreenModel

### DIFF
--- a/modo-compose/build.gradle.kts
+++ b/modo-compose/build.gradle.kts
@@ -39,6 +39,12 @@ dependencies {
     // For BackHandler
     implementation("androidx.activity:activity-compose:${properties["version.composeActivity"]}")
     implementation("org.jetbrains.kotlin:kotlin-parcelize-runtime:${properties["version.kotlin"]}")
+
+    testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
+}
+
+tasks.withType(Test::class) {
+    useJUnitPlatform()
 }
 
 val sourceJar by tasks.registering(Jar::class) {

--- a/modo-compose/src/main/java/com/github/terrakok/modo/model/ScreenModelStore.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/model/ScreenModelStore.kt
@@ -25,7 +25,7 @@ public object ScreenModelStore {
 
     @PublishedApi
     internal inline fun <reified T : ScreenModel> getKey(screen: Screen, tag: String?): ScreenModelKey =
-        "${screen.screenKey}:${T::class.qualifiedName}:${tag ?: "default"}"
+        "${screen.screenKey.value}:${T::class.qualifiedName}:${tag ?: "default"}"
 
     @PublishedApi
     internal fun getDependencyKey(screenModel: ScreenModel, name: String): DependencyKey =

--- a/modo-compose/src/test/java/com/github/terrakok/modo/MockScreen.kt
+++ b/modo-compose/src/test/java/com/github/terrakok/modo/MockScreen.kt
@@ -1,0 +1,13 @@
+package com.github.terrakok.modo
+
+import androidx.compose.runtime.Composable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+class MockScreen(
+    override val screenKey: ScreenKey
+) : Screen {
+
+    @Composable
+    override fun Content() = Unit
+}

--- a/modo-compose/src/test/java/com/github/terrakok/modo/MockScreenModel.kt
+++ b/modo-compose/src/test/java/com/github/terrakok/modo/MockScreenModel.kt
@@ -1,0 +1,5 @@
+package com.github.terrakok.modo
+
+import com.github.terrakok.modo.model.ScreenModel
+
+class MockScreenModel(val id: String = "") : ScreenModel

--- a/modo-compose/src/test/java/com/github/terrakok/modo/model/ScreenModelStoreTest.kt
+++ b/modo-compose/src/test/java/com/github/terrakok/modo/model/ScreenModelStoreTest.kt
@@ -1,0 +1,49 @@
+package com.github.terrakok.modo.model
+
+import com.github.terrakok.modo.MockScreen
+import com.github.terrakok.modo.MockScreenModel
+import com.github.terrakok.modo.ScreenKey
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ScreenModelStoreTest {
+
+    @Test
+    fun `When screen is removed - than screen model is removed too`() {
+        // Given
+        val store = ScreenModelStore
+        val key = ScreenKey("screen")
+        val screen = MockScreen(key)
+        store.getOrPut(screen = screen, tag = null) {
+            MockScreenModel()
+        }
+
+        // When
+        store.remove(screen)
+
+        // Then
+        assertEquals(
+            0,
+            store.screenModels.size
+        )
+    }
+
+    @Test
+    fun `When get screen model repeatedly on the same screen - then returns the same one`() {
+        // Given
+        val store = ScreenModelStore
+        val key = ScreenKey("screen")
+        val screen = MockScreen(key)
+        val screenModel = MockScreenModel(id = "1")
+        store.getOrPut(screen = screen, tag = null) {
+            screenModel
+        }
+
+        // When
+        val actualScreenModel = store.getOrPut(screen = screen, tag = null) {
+            MockScreenModel(id = "2")
+        }
+
+        assertEquals(screenModel, actualScreenModel)
+    }
+}


### PR DESCRIPTION
For now, there is a problem with clearing screen model when screen is removed, it just remains.

The problem is in the key generation for screen model. This PR fixes it, also adds unit-tests a bit to keep it working.