### PR TITLE
Add support for AndroidX Lifecycle/ViewModel/SavedState

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ version.junit=4.13.2
 version.compose=1.3.0
 kotlin.native.enableDependencyPropagation=false
 android.minSdk=21
-version.lifecycleRuntimeKtx=2.5.1
+version.lifecycle=2.5.1
 org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 android.useAndroidX=true
 version.kotlin=1.7.20

--- a/modo-compose/build.gradle.kts
+++ b/modo-compose/build.gradle.kts
@@ -39,6 +39,8 @@ dependencies {
     // For BackHandler
     implementation("androidx.activity:activity-compose:${properties["version.composeActivity"]}")
     implementation("org.jetbrains.kotlin:kotlin-parcelize-runtime:${properties["version.kotlin"]}")
+    // For LocalViewModelStoreOwner
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:${properties["version.lifecycle"]}")
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
 }

--- a/modo-compose/src/main/java/com/github/terrakok/modo/ComposeRender.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/ComposeRender.kt
@@ -1,32 +1,52 @@
 package com.github.terrakok.modo
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.neverEqualPolicy
+import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.SaveableStateHolder
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
-import androidx.compose.runtime.setValue
-import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.platform.LocalSavedStateRegistryOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import com.github.terrakok.modo.lifecycle.LifecycleHandler
 import com.github.terrakok.modo.model.ScreenModelStore
 import com.github.terrakok.modo.util.currentOrThrow
+import kotlinx.coroutines.channels.Channel
 
 typealias RendererContent<State> = @Composable ComposeRendererScope<State>.() -> Unit
 
-val defaultRendererContent: (@Composable ComposeRendererScope<*>.() -> Unit) = { screen.SaveableContent() }
-
-internal val LocalSaveableStateHolder = staticCompositionLocalOf<SaveableStateHolder?> { null }
-
-@Composable
-fun Screen.SaveableContent() {
-    LocalSaveableStateHolder.currentOrThrow.SaveableStateProvider(key = screenKey) {
-        Content()
+val defaultRendererContent: (@Composable ComposeRendererScope<*>.() -> Unit) = {
+    screen.SaveableContent()
+    val channel = LocalTransitionCompleteChannel.current
+    // There's no animation so we can instantly mark the transition as completed
+    DisposableEffect(screen.screenKey) {
+        onDispose {
+            channel.trySend(Unit)
+        }
     }
 }
 
-class ComposeRendererScope<State: NavigationState>(
+internal val LocalSaveableStateHolder = staticCompositionLocalOf<SaveableStateHolder?> { null }
+
+internal val LocalTransitionCompleteChannel =
+    staticCompositionLocalOf<Channel<Unit>> { error("no channel provided") }
+
+@Composable
+fun Screen.SaveableContent() {
+    // The current visible screen should sync with parent's lifecycle (Activity, Fragment or
+    // ContainerScreen)
+    val parentLifecycle = LocalLifecycleOwner.current.lifecycle
+    CompositionLocalProvider(
+        LocalLifecycleOwner provides this,
+        LocalViewModelStoreOwner provides this,
+        LocalSavedStateRegistryOwner provides this,
+    ) {
+        LocalSaveableStateHolder.currentOrThrow.SaveableStateProvider(key = screenKey) {
+            LifecycleHandler(parentLifecycle)
+            Content()
+        }
+    }
+}
+
+class ComposeRendererScope<State : NavigationState>(
     val oldState: State?,
     val newState: State?,
     val screen: Screen,
@@ -34,10 +54,10 @@ class ComposeRendererScope<State: NavigationState>(
 
 /**
  * Renderer responsibilities:
- *  1. Rendering - wrapping state to composable state and delegating rendering to screens
- *  2. Storing and clearing composable states inside [SaveableStateHolder]
+ * 1. Rendering - wrapping state to composable state and delegating rendering to screens
+ * 2. Storing and clearing composable states inside [SaveableStateHolder]
  */
-internal class ComposeRenderer<State: NavigationState>(
+internal class ComposeRenderer<State : NavigationState>(
     private val containerScreen: ContainerScreen<*>,
 ) : NavigationRenderer<State> {
 
@@ -48,6 +68,12 @@ internal class ComposeRenderer<State: NavigationState>(
     // TODO: share removed screen for whole structure
     private val removedScreens = mutableSetOf<Screen>()
 
+    /**
+     * A channel that is used to notify about completing of screen transition, so we can dispose
+     * screen that is removed out of the backstack properly.
+     */
+    private val transitionCompleteChannel: Channel<Unit> = Channel(Channel.CONFLATED)
+
     override fun render(state: State) {
         this.state?.let { currentState ->
             removedScreens.addAll(calculateRemovedScreens(currentState, state))
@@ -57,20 +83,23 @@ internal class ComposeRenderer<State: NavigationState>(
     }
 
     @Composable
-    fun Content(
-        screen: Screen,
-        content: RendererContent<State> = defaultRendererContent
-    ) {
+    fun Content(screen: Screen, content: RendererContent<State> = defaultRendererContent) {
         // use single state holder for whole hierarchy, store it on top of it
-        val stateHolder: SaveableStateHolder = LocalSaveableStateHolder.current ?: rememberSaveableStateHolder()
-        DisposableEffect(key1 = state) {
-            onDispose {
+        val stateHolder: SaveableStateHolder =
+            LocalSaveableStateHolder.current ?: rememberSaveableStateHolder()
+
+        LaunchedEffect(
+            key1 = screen.screenKey,
+        ) {
+            for (event in transitionCompleteChannel) {
                 clearScreens(stateHolder)
             }
         }
+
         CompositionLocalProvider(
             LocalSaveableStateHolder providesDefault stateHolder,
-            LocalContainerScreen provides containerScreen
+            LocalContainerScreen provides containerScreen,
+            LocalTransitionCompleteChannel provides transitionCompleteChannel,
         ) {
             ComposeRendererScope(lastState, state, screen).content()
         }
@@ -78,8 +107,10 @@ internal class ComposeRenderer<State: NavigationState>(
 
     /**
      * Clear states of removed screens from given [stateHolder].
-     * @param stateHolder - SaveableStateHolder that contains screen states
-     * @param clearAll - forces to remove all screen states that renderer holds (removed and "displayed")
+     * @param stateHolder
+     * - SaveableStateHolder that contains screen states
+     * @param clearAll
+     * - forces to remove all screen states that renderer holds (removed and "displayed")
      */
     private fun clearScreens(stateHolder: SaveableStateHolder, clearAll: Boolean = false) {
         if (clearAll) {
@@ -91,16 +122,24 @@ internal class ComposeRenderer<State: NavigationState>(
         }
     }
 
-    private fun Iterable<Screen>.clearStates(stateHolder: SaveableStateHolder) = forEach { screen ->
+    private fun Iterable<Screen>.clearStates(
+        stateHolder: SaveableStateHolder,
+    ) = forEach { screen ->
         ScreenModelStore.remove(screen)
         stateHolder.removeState(screen.screenKey)
+        screen.onDispose()
         // clear nested screens using recursion
-        ((screen as? ContainerScreen<*>)?.renderer as? ComposeRenderer<*>)?.clearScreens(stateHolder, clearAll = true)
+        ((screen as? ContainerScreen<*>)?.renderer as? ComposeRenderer<*>)?.clearScreens(
+            stateHolder = stateHolder,
+            clearAll = true
+        )
     }
 
-    private fun calculateRemovedScreens(oldState: NavigationState, newState: NavigationState): List<Screen> {
+    private fun calculateRemovedScreens(
+        oldState: NavigationState,
+        newState: NavigationState
+    ): List<Screen> {
         val newChainSet = newState.getChildScreens()
         return oldState.getChildScreens().filter { it !in newChainSet }
     }
-
 }

--- a/modo-compose/src/main/java/com/github/terrakok/modo/ComposeScreen.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/ComposeScreen.kt
@@ -2,12 +2,13 @@ package com.github.terrakok.modo
 
 import android.os.Parcelable
 import androidx.compose.runtime.Composable
+import com.github.terrakok.modo.lifecycle.ScreenLifecycle
+import com.github.terrakok.modo.lifecycle.ScreenLifecycleImpl
 
-interface Screen : Parcelable {
+abstract class Screen(
+    val screenKey: ScreenKey,
+) : Parcelable, ScreenLifecycle by ScreenLifecycleImpl(screenKey) {
 
     @Composable
-    fun Content()
-
-    val screenKey: ScreenKey
-
+    abstract fun Content()
 }

--- a/modo-compose/src/main/java/com/github/terrakok/modo/ContainerScreen.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/ContainerScreen.kt
@@ -10,14 +10,12 @@ val LocalContainerScreen = staticCompositionLocalOf<ContainerScreen<*>> { error(
 
 abstract class ContainerScreen<State : NavigationState>(
     private val navModel: NavModel<State>
-) : Screen, NavigationContainer<State> by navModel {
+) : Screen(navModel.screenKey), NavigationContainer<State> by navModel {
 
     abstract val reducer: NavigationReducer<State>
 
     internal val renderer: NavigationRenderer<State>?
         get() = navModel.renderer
-
-    final override val screenKey: ScreenKey = navModel.screenKey
 
     init {
         navModel.init(

--- a/modo-compose/src/main/java/com/github/terrakok/modo/DialogScreen.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/DialogScreen.kt
@@ -3,8 +3,7 @@ package com.github.terrakok.modo
 import androidx.compose.ui.window.DialogProperties
 
 @ExperimentalModoApi
-interface DialogScreen : Screen {
+abstract class DialogScreen(screenKey: ScreenKey) : Screen(screenKey) {
 
     fun provideDialogProperties(): DialogProperties = DialogProperties()
-
 }

--- a/modo-compose/src/main/java/com/github/terrakok/modo/animation/ScreenTransitions.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/animation/ScreenTransitions.kt
@@ -1,19 +1,13 @@
 package com.github.terrakok.modo.animation
 
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.AnimatedContentScope
-import androidx.compose.animation.AnimatedVisibilityScope
-import androidx.compose.animation.ContentTransform
-import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.*
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.updateTransition
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.scaleIn
-import androidx.compose.animation.with
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import com.github.terrakok.modo.ComposeRendererScope
+import com.github.terrakok.modo.LocalTransitionCompleteChannel
 import com.github.terrakok.modo.SaveableContent
 import com.github.terrakok.modo.Screen
 
@@ -25,16 +19,22 @@ fun ComposeRendererScope<*>.ScreenTransition(
     modifier: Modifier = Modifier,
     transitionSpec: AnimatedContentScope<Screen>.() -> ContentTransform = {
         fadeIn(animationSpec = tween(220, delayMillis = 90)) +
-            scaleIn(initialScale = 0.92f, animationSpec = tween(220, delayMillis = 90)) with
-            fadeOut(animationSpec = tween(90))
+                scaleIn(initialScale = 0.92f, animationSpec = tween(220, delayMillis = 90)) with
+                fadeOut(animationSpec = tween(90))
     },
-    content: ScreenTransitionContent = { it.SaveableContent() }
+    content: ScreenTransitionContent = { it.SaveableContent() },
 ) {
     val transition = updateTransition(targetState = screen, label = "ScreenTransition")
     transition.AnimatedContent(
         transitionSpec = transitionSpec,
         modifier = modifier,
         contentKey = { it.screenKey },
-        content = content
+        content = content,
     )
+    if (transition.currentState == transition.targetState) {
+        val channel = LocalTransitionCompleteChannel.current
+        LaunchedEffect(Unit) {
+            channel.trySend(Unit)
+        }
+    }
 }

--- a/modo-compose/src/main/java/com/github/terrakok/modo/lifecycle/ScreenLifecycle.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/lifecycle/ScreenLifecycle.kt
@@ -1,0 +1,147 @@
+package com.github.terrakok.modo.lifecycle
+
+import android.app.Activity
+import android.app.Application
+import android.content.Context
+import android.content.ContextWrapper
+import android.os.Bundle
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.*
+import androidx.savedstate.SavedStateRegistry
+import androidx.savedstate.SavedStateRegistryController
+import androidx.savedstate.SavedStateRegistryOwner
+import com.github.terrakok.modo.Screen
+import com.github.terrakok.modo.ScreenKey
+
+interface ScreenLifecycle :
+    LifecycleOwner,
+    ViewModelStoreOwner,
+    SavedStateRegistryOwner,
+    HasDefaultViewModelProviderFactory {
+
+    var parentLifecycleState: Lifecycle.State
+
+    fun setApplication(app: Application?)
+
+    fun updateLifecycleState(state: Lifecycle.State)
+
+    fun performRestore(savedState: Bundle?)
+
+    fun performSave(outState: Bundle)
+
+    fun onDispose()
+}
+
+class ScreenLifecycleImpl(
+    val screenKey: ScreenKey,
+) : ScreenLifecycle {
+
+    override var parentLifecycleState: Lifecycle.State = Lifecycle.State.CREATED
+        set(state) {
+            if (field == state) return
+            field = state
+            updateLifecycleState(state)
+        }
+
+    private val lifecycle = LifecycleRegistry(this)
+    private val savedStateRegistryController = SavedStateRegistryController.create(this)
+    private val store = ViewModelStore()
+
+    private var app: Application? = null
+
+    private val defaultFactory by lazy { SavedStateViewModelFactory(app, this) }
+
+    private var savedStateRegistryRestored = false
+
+    override fun setApplication(app: Application?) {
+        this.app = app
+    }
+
+    override fun getLifecycle(): Lifecycle = lifecycle
+
+    override fun getViewModelStore(): ViewModelStore = store
+
+    override val savedStateRegistry: SavedStateRegistry =
+        savedStateRegistryController.savedStateRegistry
+
+    override fun getDefaultViewModelProviderFactory(): ViewModelProvider.Factory {
+        return defaultFactory
+    }
+
+    override fun updateLifecycleState(state: Lifecycle.State) {
+        if (lifecycle.currentState == state) return
+        lifecycle.currentState = state
+    }
+
+    override fun performRestore(savedState: Bundle?) {
+        // Perform the restore just once and before we move up the Lifecycle
+        if (!savedStateRegistryRestored) {
+            enableSavedStateHandles()
+            savedStateRegistryController.performRestore(savedState)
+            savedStateRegistryRestored = true
+        }
+    }
+
+    override fun performSave(outState: Bundle) {
+        savedStateRegistryController.performSave(outState)
+    }
+
+    override fun onDispose() {
+        store.clear()
+        updateLifecycleState(Lifecycle.State.DESTROYED)
+    }
+}
+
+private val startEvents =
+    arrayOf(Lifecycle.Event.ON_CREATE, Lifecycle.Event.ON_START, Lifecycle.Event.ON_RESUME)
+
+private val stopEvents = arrayOf(Lifecycle.Event.ON_PAUSE, Lifecycle.Event.ON_STOP)
+
+@Composable
+internal fun Screen.LifecycleHandler(parentLifecycle: Lifecycle) {
+    val savedState = rememberSaveable(key = "${screenKey.value}:bundle") { Bundle() }
+    val activity = LocalContext.current.findActivity()
+    setApplication(activity?.application)
+    performRestore(savedState)
+    DisposableEffect(Unit) {
+        startEvents.forEach { updateLifecycleState(it.targetState) }
+        parentLifecycleState = parentLifecycle.currentState
+        val observer = LifecycleEventObserver { source, event ->
+            if (event == Lifecycle.Event.ON_DESTROY && activity?.isChangingConfigurations == true) {
+                /**
+                 * Instance of the screen isn't recreated during config changes so skip this event
+                 * to avoid crash while accessing to ViewModel with SavedStateHandle, because after
+                 * ON_DESTROY, [androidx.lifecycle.SavedStateHandleController] is marked as not
+                 * attached and next call of [registerSavedStateProvider] after recreating Activity
+                 * on the same instance causing the crash.
+                 */
+                return@LifecycleEventObserver
+            }
+            if (event == Lifecycle.Event.ON_STOP) {
+                performSave(savedState)
+            }
+            parentLifecycleState = source.lifecycle.currentState
+        }
+        parentLifecycle.addObserver(observer)
+        onDispose {
+            performSave(savedState)
+            stopEvents.forEach {
+                // don't move up lifecycle state if the parent state is lower than event's one
+                if (it.targetState < parentLifecycleState) {
+                    updateLifecycleState(it.targetState)
+                }
+            }
+            parentLifecycle.removeObserver(observer)
+        }
+    }
+}
+
+private fun Context.findActivity(): Activity? =
+    when (this) {
+        is Activity -> this
+        is ContextWrapper -> baseContext.findActivity()
+        else -> null
+    }

--- a/modo-compose/src/test/java/com/github/terrakok/modo/MockScreen.kt
+++ b/modo-compose/src/test/java/com/github/terrakok/modo/MockScreen.kt
@@ -1,13 +1,15 @@
 package com.github.terrakok.modo
 
+import android.os.Parcel
 import androidx.compose.runtime.Composable
 import kotlinx.parcelize.Parcelize
 
-@Parcelize
-class MockScreen(
-    override val screenKey: ScreenKey
-) : Screen {
+fun MockScreen(key: ScreenKey): Screen = object : Screen(key) {
 
     @Composable
     override fun Content() = Unit
+
+    override fun describeContents(): Int = 0
+
+    override fun writeToParcel(dest: Parcel, flags: Int) = Unit
 }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -42,6 +42,6 @@ dependencies {
     implementation("androidx.compose.ui:ui:${properties["version.compose"]}")
     implementation("androidx.compose.material:material:${properties["version.material"]}")
     implementation("androidx.compose.ui:ui-tooling:${properties["version.compose"]}")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:${properties["version.lifecycleRuntimeKtx"]}")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:${properties["version.lifecycle"]}")
     implementation("androidx.activity:activity-compose:${properties["version.composeActivity"]}")
 }

--- a/sample/src/main/java/com/github/terrakok/androidcomposeapp/playground/SaveableStateHolderDemoScreen.kt
+++ b/sample/src/main/java/com/github/terrakok/androidcomposeapp/playground/SaveableStateHolderDemoScreen.kt
@@ -33,9 +33,7 @@ import kotlinx.parcelize.Parcelize
 import kotlin.random.Random
 
 @Parcelize
-class SaveableStateHolderDemoScreen(
-    override val screenKey: ScreenKey = generateScreenKey()
-) : Screen {
+class SaveableStateHolderDemoScreen : Screen(screenKey = generateScreenKey()) {
 
     @Composable
     override fun Content() {
@@ -77,7 +75,11 @@ private fun ScreenContent() {
 //                    .weight(1f)
 //                    .fillMaxWidth()
 //            )
-        BottomBar(screens1.size, selectedPos, changeDisplayTypeClick = { showAllStacks = !showAllStacks }, onTabClick = { selectedPos = it })
+        BottomBar(
+            screens1.size,
+            selectedPos,
+            changeDisplayTypeClick = { showAllStacks = !showAllStacks },
+            onTabClick = { selectedPos = it })
     }
 
 }

--- a/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/ListDetails.kt
+++ b/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/ListDetails.kt
@@ -24,9 +24,7 @@ import com.github.terrakok.modo.stack.StackScreen
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-class ListScreen(
-    override val screenKey: ScreenKey = generateScreenKey()
-) : Screen {
+class ListScreen: Screen(screenKey = generateScreenKey()) {
 
     @Composable
     override fun Content() {
@@ -44,10 +42,10 @@ class ListScreen(
             ) {
                 items((1..100).toList()) {
                     Text(text = "Item $it",
-                         Modifier
-                             .fillMaxWidth()
-                             .clickable { conScreen.forward(DetailsScreen(it.toString())) }
-                             .padding(16.dp))
+                        Modifier
+                            .fillMaxWidth()
+                            .clickable { conScreen.forward(DetailsScreen(it.toString())) }
+                            .padding(16.dp))
                 }
             }
         }
@@ -57,8 +55,7 @@ class ListScreen(
 @Parcelize
 class DetailsScreen(
     private val userId: String,
-    override val screenKey: ScreenKey = generateScreenKey()
-) : Screen {
+) : Screen(screenKey = generateScreenKey()) {
 
     @Composable
     override fun Content() {

--- a/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/ModelSampleScreen.kt
+++ b/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/ModelSampleScreen.kt
@@ -18,9 +18,7 @@ import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-class ModelSampleScreen(
-    override val screenKey: ScreenKey = generateScreenKey()
-) : Screen {
+class ModelSampleScreen : Screen(screenKey = generateScreenKey()) {
 
     @Composable
     override fun Content() {

--- a/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/SampleDialog.kt
+++ b/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/SampleDialog.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.unit.dp
 import com.github.terrakok.modo.DialogScreen
 import com.github.terrakok.modo.ExperimentalModoApi
 import com.github.terrakok.modo.LocalContainerScreen
-import com.github.terrakok.modo.ScreenKey
 import com.github.terrakok.modo.generateScreenKey
 import com.github.terrakok.modo.stack.StackScreen
 import kotlinx.parcelize.Parcelize
@@ -20,8 +19,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 class SampleDialog(
     private val i: Int,
-    override val screenKey: ScreenKey = generateScreenKey()
-) : DialogScreen {
+) : DialogScreen(screenKey = generateScreenKey()) {
 
     @Composable
     override fun Content() {

--- a/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/SampleScreen.kt
+++ b/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/SampleScreen.kt
@@ -45,8 +45,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 class SampleScreen(
     private val i: Int,
-    override val screenKey: ScreenKey = generateScreenKey()
-) : Screen {
+) : Screen(screenKey = generateScreenKey()) {
 
     @Composable
     override fun Content() {


### PR DESCRIPTION
This PR adds support for androidx.lifecycle which allows to use ViewModel out of box and also covers some usecases where user wants to track lifecycle of the screen for some business-logic.

Which scenarios was tested:
1. Lifecycle ordering during animated transition (also w/o animation). Screen is disposed only after transition is completed. The incoming screen getting upward lifecycle states first, after it outgoing screen gets downward states.
2. ViewModel creation with custom ViewModel.Factory and default one.
3. Config changes. (Instance of ViewModel was the same)
4. SavedState functional. Writing some data to the instance of SavedState with further reading from it after process restoration.

@KarenkovID Have a good review =)