### PR TITLE
Improved container screens implementation

### DIFF
--- a/modo-compose/src/main/java/com/github/terrakok/modo/ComposeRender.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/ComposeRender.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.ProvidedValue
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.neverEqualPolicy
@@ -94,6 +95,7 @@ internal class ComposeRenderer<State : NavigationState>(
     @Composable
     fun Content(
         screen: Screen,
+        provideCompositionLocal: Array<ProvidedValue<*>> = emptyArray(),
         modifier: Modifier = Modifier,
         content: RendererContent<State> = defaultRendererContent
     ) {
@@ -116,6 +118,7 @@ internal class ComposeRenderer<State : NavigationState>(
         CompositionLocalProvider(
             LocalContainerScreen provides containerScreen,
             LocalTransitionCompleteChannel provides transitionCompleteChannel,
+            *provideCompositionLocal
         ) {
             ComposeRendererScope(lastState, state, screen).content(modifier)
         }

--- a/modo-compose/src/main/java/com/github/terrakok/modo/ContainerScreen.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/ContainerScreen.kt
@@ -3,6 +3,7 @@ package com.github.terrakok.modo
 import android.os.Parcel
 import android.os.Parcelable
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ProvidedValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 
@@ -33,6 +34,22 @@ abstract class ContainerScreen<State : NavigationState, Action : NavigationActio
         )
     }
 
+    /**
+     * This function can be used to provide composition locals for inner screens.
+     * This is used in implementations of ContainerScreen to provide typed composition locals to container.
+     * @see com.github.terrakok.modo.stack.LocalStackNavigation
+     */
+    open fun provideCompositionLocals(): Array<ProvidedValue<*>> =
+        provideNavigationContainer()
+            ?.let { arrayOf(it) }
+            ?: emptyArray()
+
+    /**
+     * Provides composition local for the nested hierarchy to receive NavigationContainer.
+     * @see com.github.terrakok.modo.stack.LocalStackNavigation
+     */
+    open fun provideNavigationContainer(): ProvidedValue<out NavigationContainer<*, *>>? = null
+
     @Composable
     protected fun InternalContent(
         screen: Screen,
@@ -40,7 +57,7 @@ abstract class ContainerScreen<State : NavigationState, Action : NavigationActio
         content: RendererContent<State> = defaultRendererContent
     ) {
         val composeRenderer = renderer as ComposeRenderer
-        composeRenderer.Content(screen, modifier, content)
+        composeRenderer.Content(screen, provideCompositionLocals(), modifier, content)
     }
 
     override fun toString(): String = screenKey.value

--- a/modo-compose/src/main/java/com/github/terrakok/modo/Modo.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/Modo.kt
@@ -34,7 +34,7 @@ object Modo {
     /**
      * Must be called to clear all data from [ScreenModelStore], related with removed screens.
      */
-    fun <T: ContainerScreen<*, *>> onRootScreenFinished(rootScreen: RootScreen<T>?) {
+    fun <T : ContainerScreen<*, *>> onRootScreenFinished(rootScreen: RootScreen<T>?) {
         rootScreen?.screen?.let(::clearScreenModel)
     }
 

--- a/modo-compose/src/main/java/com/github/terrakok/modo/RootScreen.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/RootScreen.kt
@@ -9,7 +9,7 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 class RootScreenState<T : Screen>(
-    private val screen: T
+    internal val screen: T
 ) : NavigationState {
     override fun getChildScreens(): List<Screen> = listOf(screen)
 }
@@ -18,13 +18,15 @@ class RootScreenState<T : Screen>(
  * Screen for single source of providing [LocalSaveableStateHolder]. Should be used with [Modo.init].
  */
 @Parcelize
-class RootScreen<T : Screen>(
-    val screen: T,
-    private val navModel: NavModel<RootScreenState<T>, NavigationAction<RootScreenState<T>>> =
-        NavModel(RootScreenState(screen))
+class RootScreen<T : Screen> internal constructor(
+    private val navModel: NavModel<RootScreenState<T>, NavigationAction<RootScreenState<T>>>
 ) : ContainerScreen<RootScreenState<T>, NavigationAction<RootScreenState<T>>>(
     navModel
 ) {
+
+    constructor(screen: T) : this(NavModel(RootScreenState(screen)))
+
+    val screen: T get() = navigationState.screen
 
     @Composable
     override fun Content(modifier: Modifier) {
@@ -32,7 +34,7 @@ class RootScreen<T : Screen>(
         CompositionLocalProvider(
             LocalSaveableStateHolder providesDefault stateHolder
         ) {
-            InternalContent(screen, modifier)
+            InternalContent(navigationState.screen, modifier)
         }
     }
 

--- a/modo-compose/src/main/java/com/github/terrakok/modo/RootScreen.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/RootScreen.kt
@@ -7,14 +7,24 @@ import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.Modifier
 import kotlinx.parcelize.Parcelize
 
+@Parcelize
+class RootScreenState<T : Screen>(
+    private val screen: T
+) : NavigationState {
+    override fun getChildScreens(): List<Screen> = listOf(screen)
+}
+
 /**
  * Screen for single source of providing [LocalSaveableStateHolder]. Should be used with [Modo.init].
  */
 @Parcelize
 class RootScreen<T : Screen>(
     val screen: T,
-    override val screenKey: ScreenKey = generateScreenKey()
-) : Screen {
+    private val navModel: NavModel<RootScreenState<T>, NavigationAction<RootScreenState<T>>> =
+        NavModel(RootScreenState(screen))
+) : ContainerScreen<RootScreenState<T>, NavigationAction<RootScreenState<T>>>(
+    navModel
+) {
 
     @Composable
     override fun Content(modifier: Modifier) {
@@ -22,7 +32,7 @@ class RootScreen<T : Screen>(
         CompositionLocalProvider(
             LocalSaveableStateHolder providesDefault stateHolder
         ) {
-            screen.Content(modifier)
+            InternalContent(screen, modifier)
         }
     }
 

--- a/modo-compose/src/main/java/com/github/terrakok/modo/multiscreen/MultiScreen.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/multiscreen/MultiScreen.kt
@@ -1,27 +1,36 @@
 package com.github.terrakok.modo.multiscreen
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import com.github.terrakok.modo.ContainerScreen
 import com.github.terrakok.modo.RendererContent
 import com.github.terrakok.modo.Screen
 import com.github.terrakok.modo.defaultRendererContent
 
+val LocalMultiScreenNavigation: ProvidableCompositionLocal<MultiScreenNavContainer> = staticCompositionLocalOf {
+    error("There is no MultiScreenContainer in hierarchy, or maybe you override provideCompositionLocal and forgot to call supper.")
+}
+
 abstract class MultiScreen(
     navigationModel: MultiScreenNavModel
-) : ContainerScreen<MultiScreenState, MultiScreenAction>(navigationModel), MultiScreenContainer {
+) : ContainerScreen<MultiScreenState, MultiScreenAction>(navigationModel), MultiScreenNavContainer {
 
     @Composable
     override fun Content(modifier: Modifier) {
         SelectedScreen()
     }
 
+    override fun provideNavigationContainer() = LocalMultiScreenNavigation provides this
+
     @Composable
     fun SelectedScreen(
         modifier: Modifier = Modifier,
         content: RendererContent<MultiScreenState> = defaultRendererContent
     ) {
-        Content(navigationState.containers[navigationState.selected], modifier, content)
+        val (screens, selectedPos) = navigationState
+        Content(screens[selectedPos], modifier, content)
     }
 
     @Composable

--- a/modo-compose/src/main/java/com/github/terrakok/modo/multiscreen/MultiScreenActions.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/multiscreen/MultiScreenActions.kt
@@ -17,7 +17,7 @@ class SelectContainer(private val index: Int) : MultiScreenReducerAction {
         oldState.copy(selected = index)
 }
 
-fun MultiScreenContainer.dispatch(action: (MultiScreenState) -> MultiScreenState) = dispatch(MultiScreenReducerAction(action))
+fun MultiScreenNavContainer.dispatch(action: (MultiScreenState) -> MultiScreenState) = dispatch(MultiScreenReducerAction(action))
 
 fun NavigationContainer<MultiScreenState, MultiScreenAction>.setContainers(state: MultiScreenState) = dispatch(SetContainers(state))
 fun NavigationContainer<MultiScreenState, MultiScreenAction>.selectContainer(index: Int) = dispatch(SelectContainer(index))

--- a/modo-compose/src/main/java/com/github/terrakok/modo/multiscreen/MultiScreenState.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/multiscreen/MultiScreenState.kt
@@ -1,7 +1,6 @@
 package com.github.terrakok.modo.multiscreen
 
 import android.os.Parcelable
-import com.github.terrakok.modo.ContainerScreen
 import com.github.terrakok.modo.NavModel
 import com.github.terrakok.modo.NavigationContainer
 import com.github.terrakok.modo.NavigationState
@@ -10,17 +9,17 @@ import kotlinx.parcelize.Parcelize
 
 typealias MultiScreenNavModel = NavModel<MultiScreenState, MultiScreenAction>
 
-interface MultiScreenContainer : NavigationContainer<MultiScreenState, MultiScreenAction>
+interface MultiScreenNavContainer : NavigationContainer<MultiScreenState, MultiScreenAction>
 
 fun MultiScreenNavModel(
-    containers: List<ContainerScreen<*, *>>,
+    containers: List<Screen>,
     selected: Int
 ) = MultiScreenNavModel(MultiScreenState(containers, selected))
 
 @Parcelize
 data class MultiScreenState(
-    val containers: List<ContainerScreen<*, *>>,
+    val screens: List<Screen>,
     val selected: Int
 ) : NavigationState, Parcelable {
-    override fun getChildScreens(): List<Screen> = containers
+    override fun getChildScreens(): List<Screen> = screens
 }

--- a/modo-compose/src/main/java/com/github/terrakok/modo/stack/StackActions.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/stack/StackActions.kt
@@ -1,6 +1,7 @@
 package com.github.terrakok.modo.stack
 
 import com.github.terrakok.modo.NavigationAction
+import com.github.terrakok.modo.NavigationContainer
 import com.github.terrakok.modo.ReducerAction
 import com.github.terrakok.modo.Screen
 import com.github.terrakok.modo.ScreenKey
@@ -40,9 +41,9 @@ class BackTo(val backToCondition: (pos: Int, screen: Screen) -> Boolean) : Stack
         }
     )
 
-    constructor(screen: Screen) : this(
+    constructor(screenBackTo: Screen) : this(
         { _, screen ->
-            screen == screen
+            screen == screenBackTo
         }
     )
 
@@ -77,17 +78,17 @@ class Back(private val screensToDrop: Int = 1) : StackReducerAction {
     )
 }
 
-fun StackNavigationContainer.dispatch(action: (StackState) -> StackState) = dispatch(StackReducerAction(action))
+fun StackNavContainer.dispatch(action: (StackState) -> StackState) = dispatch(StackReducerAction(action))
 
-fun StackContainer.setStack(state: StackState) = dispatch(SetStack(state))
-fun StackContainer.forward(screen: Screen, vararg screens: Screen) = dispatch(Forward(screen, *screens))
-fun StackContainer.replace(screen: Screen, vararg screens: Screen) = dispatch(Replace(screen, *screens))
-fun StackContainer.newStack(screen: Screen, vararg screens: Screen) = dispatch(NewStack(screen, *screens))
+fun NavigationContainer<StackState, StackAction>.setStack(state: StackState) = dispatch(SetStack(state))
+fun NavigationContainer<StackState, StackAction>.forward(screen: Screen, vararg screens: Screen) = dispatch(Forward(screen, *screens))
+fun NavigationContainer<StackState, StackAction>.replace(screen: Screen, vararg screens: Screen) = dispatch(Replace(screen, *screens))
+fun NavigationContainer<StackState, StackAction>.newStack(screen: Screen, vararg screens: Screen) = dispatch(NewStack(screen, *screens))
 
-inline fun <reified T : Screen> StackContainer.backTo() = dispatch(BackTo<T>())
-fun StackContainer.backTo(screen: Screen) = dispatch(BackTo(screen))
-fun StackContainer.backTo(screenKey: ScreenKey) = dispatch(BackTo(screenKey))
-fun StackContainer.backTo(backToCondition: (pos: Int, screen: Screen) -> Boolean) = dispatch(BackTo(backToCondition))
+inline fun <reified T : Screen> NavigationContainer<StackState, StackAction>.backTo() = dispatch(BackTo<T>())
+fun NavigationContainer<StackState, StackAction>.backTo(screen: Screen) = dispatch(BackTo(screen))
+fun NavigationContainer<StackState, StackAction>.backTo(screenKey: ScreenKey) = dispatch(BackTo(screenKey))
+fun NavigationContainer<StackState, StackAction>.backTo(backToCondition: (pos: Int, screen: Screen) -> Boolean) = dispatch(BackTo(backToCondition))
 
-fun StackContainer.removeScreens(condition: (pos: Int, screen: Screen) -> Boolean) = dispatch(RemoveScreens(condition))
-fun StackContainer.back(screensToDrop: Int = 1) = dispatch(Back(screensToDrop))
+fun NavigationContainer<StackState, StackAction>.removeScreens(condition: (pos: Int, screen: Screen) -> Boolean) = dispatch(RemoveScreens(condition))
+fun NavigationContainer<StackState, StackAction>.back(screensToDrop: Int = 1) = dispatch(Back(screensToDrop))

--- a/modo-compose/src/main/java/com/github/terrakok/modo/stack/StackScreen.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/stack/StackScreen.kt
@@ -6,11 +6,14 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.ProvidedValue
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.window.Dialog
@@ -20,7 +23,6 @@ import com.github.terrakok.modo.ComposeRenderer
 import com.github.terrakok.modo.ContainerScreen
 import com.github.terrakok.modo.DialogScreen
 import com.github.terrakok.modo.ExperimentalModoApi
-import com.github.terrakok.modo.NavigationContainer
 import com.github.terrakok.modo.RendererContent
 import com.github.terrakok.modo.Screen
 import com.github.terrakok.modo.ScreenKey
@@ -28,14 +30,16 @@ import com.github.terrakok.modo.defaultRendererContent
 import com.github.terrakok.modo.generateScreenKey
 import kotlinx.parcelize.Parcelize
 
-typealias StackContainer = NavigationContainer<StackState, StackAction>
+val LocalStackNavigation: ProvidableCompositionLocal<StackNavContainer> = staticCompositionLocalOf {
+    error("There is no LocalStackNavigation in hierarchy, or maybe you override provideCompositionLocal and forgot to call supper.")
+}
 
 /**
  * Basic screen container that represents stack of [Screen]'s.
  */
 abstract class StackScreen(
     navigationModel: StackNavModel
-) : ContainerScreen<StackState, StackAction>(navigationModel), StackNavigationContainer {
+) : ContainerScreen<StackState, StackAction>(navigationModel), StackNavContainer {
 
     open val defaultBackHandler: Boolean = true
 
@@ -46,6 +50,9 @@ abstract class StackScreen(
     override fun Content(modifier: Modifier) {
         TopScreenContent(modifier)
     }
+
+    override fun provideNavigationContainer(): ProvidedValue<StackNavContainer> =
+        LocalStackNavigation provides this
 
     /**
      * The palace holder screen that is used to support animation of showing first dialog appearance.

--- a/modo-compose/src/main/java/com/github/terrakok/modo/stack/StackState.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/stack/StackState.kt
@@ -12,7 +12,7 @@ typealias StackNavModel = NavModel<StackState, StackAction>
 fun StackNavModel(stack: List<Screen>) = StackNavModel(StackState(stack))
 fun StackNavModel(screen: Screen) = StackNavModel(listOf(screen))
 
-interface StackNavigationContainer : NavigationContainer<StackState, StackAction>
+interface StackNavContainer : NavigationContainer<StackState, StackAction>
 
 @Parcelize
 data class StackState(

--- a/modo-compose/src/main/java/com/github/terrakok/modo/util/NavigationLogger.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/util/NavigationLogger.kt
@@ -31,11 +31,13 @@ private fun getNavigationStateString(prefix: String, navigationState: Navigation
             }.joinToString(separator = "")
         }
         is MultiScreenState -> buildString {
-            val screen = navigationState.containers[navigationState.selected]
+            val screen = navigationState.screens[navigationState.selected]
             append(prefix)
             append(screen.screenKey)
             appendLine()
-            append(getNavigationStateString("$prefix|  ", screen.navigationState))
+            if (screen is ContainerScreen<*, *>) {
+                append(getNavigationStateString("$prefix|  ", screen.navigationState))
+            }
         }
         else -> "unknown state type: ${navigationState::class.simpleName}"
     }

--- a/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/ListDetails.kt
+++ b/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/ListDetails.kt
@@ -15,11 +15,10 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.github.terrakok.modo.LocalContainerScreen
 import com.github.terrakok.modo.Screen
 import com.github.terrakok.modo.ScreenKey
 import com.github.terrakok.modo.generateScreenKey
-import com.github.terrakok.modo.stack.StackScreen
+import com.github.terrakok.modo.stack.LocalStackNavigation
 import com.github.terrakok.modo.stack.forward
 import kotlinx.parcelize.Parcelize
 
@@ -30,7 +29,7 @@ class ListScreen(
 
     @Composable
     override fun Content(modifier: Modifier) {
-        val conScreen = LocalContainerScreen.current as StackScreen
+        val navigation = LocalStackNavigation.current
         Box(Modifier.fillMaxSize()) {
             val lazyColumnState = rememberSaveable(saver = LazyListState.Saver) {
                 LazyListState(
@@ -46,7 +45,7 @@ class ListScreen(
                     Text(text = "Item $it",
                          Modifier
                              .fillMaxWidth()
-                             .clickable { conScreen.forward(DetailsScreen(it.toString())) }
+                             .clickable { navigation.forward(DetailsScreen(it.toString())) }
                              .padding(16.dp))
                 }
             }

--- a/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/MainScreen.kt
+++ b/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/MainScreen.kt
@@ -17,12 +17,12 @@ import com.github.terrakok.androidcomposeapp.screens.dialogs.DialogsPlayground
 import com.github.terrakok.androidcomposeapp.screens.stack.StackActionsScreen
 import com.github.terrakok.androidcomposeapp.screens.viewmodel.AndroidViewModelSampleScreen
 import com.github.terrakok.modo.ExperimentalModoApi
-import com.github.terrakok.modo.LocalContainerScreen
 import com.github.terrakok.modo.Screen
 import com.github.terrakok.modo.ScreenKey
 import com.github.terrakok.modo.generateScreenKey
 import com.github.terrakok.modo.model.OnScreenRemoved
-import com.github.terrakok.modo.stack.StackScreen
+import com.github.terrakok.modo.stack.LocalStackNavigation
+import com.github.terrakok.modo.stack.StackNavContainer
 import com.github.terrakok.modo.stack.back
 import com.github.terrakok.modo.stack.forward
 import kotlinx.parcelize.Parcelize
@@ -40,8 +40,7 @@ class MainScreen(
         OnScreenRemoved {
             logcat { "Screen $screenKey was removed" }
         }
-        val parent = LocalContainerScreen.current
-        MainScreenContent(screenIndex, screenKey, parent as? StackScreen, modifier)
+        MainScreenContent(screenIndex, screenKey, LocalStackNavigation.current, modifier)
     }
 }
 
@@ -49,14 +48,14 @@ class MainScreen(
 internal fun MainScreenContent(
     screenIndex: Int,
     screenKey: ScreenKey,
-    parent: StackScreen?,
+    navigation: StackNavContainer?,
     modifier: Modifier = Modifier,
 ) {
     ButtonsScreenContent(
         screenIndex = screenIndex,
         screenName = "MainScreen",
         screenKey = screenKey,
-        buttonsState = rememberButtons(navigator = parent, i = screenIndex),
+        buttonsState = rememberButtons(navigation = navigation, i = screenIndex),
         modifier = modifier,
     )
 }
@@ -66,14 +65,14 @@ internal fun MainScreenContent(
     screenIndex: Int,
     screenKey: ScreenKey,
     counter: Int,
-    parent: StackScreen,
+    navigation: StackNavContainer,
     modifier: Modifier
 ) {
     ButtonsScreenContent(
         screenIndex = screenIndex,
         screenName = "MainScreen",
         screenKey = screenKey,
-        buttonsState = rememberButtons(navigator = parent, i = screenIndex),
+        buttonsState = rememberButtons(navigation = navigation, i = screenIndex),
         counter = counter,
         modifier = modifier
     )
@@ -81,29 +80,29 @@ internal fun MainScreenContent(
 
 @Composable
 private fun rememberButtons(
-    navigator: StackScreen?,
+    navigation: StackNavContainer?,
     i: Int
 ): ButtonsState = remember {
     listOf<Pair<String, () -> Unit>>(
-        "Forward" to { navigator?.forward(MainScreen(i + 1)) },
-        "Back" to { navigator?.back() },
-        "Stack Playground" to { navigator?.forward(StackActionsScreen(i + 1)) },
-        "Multiscreen" to { navigator?.forward(SampleMultiScreen()) },
-        "Screen Effects" to { navigator?.forward(ScreenEffectsSampleScreen(i + 1)) },
-        "Dialogs & BottomSheets" to { navigator?.forward(DialogsPlayground(i + 1)) },
-        "Container" to { navigator?.forward(SampleContainerScreen(i + 1)) },
-        "Custom Container Actions" to { navigator?.forward(SampleCustomContainerScreen()) },
-        "Custom Container" to { navigator?.forward(RemovableItemContainerScreen()) },
-        "Horizontal Pager" to { navigator?.forward(HorizontalPagerScreen()) },
-        "Stacks in LazyColumn" to { navigator?.forward(StackInLazyColumnScreen()) },
-        "List/Details" to { navigator?.forward(ListScreen()) },
+        "Forward" to { navigation?.forward(MainScreen(i + 1)) },
+        "Back" to { navigation?.back() },
+        "Stack Playground" to { navigation?.forward(StackActionsScreen(i + 1)) },
+        "Multiscreen" to { navigation?.forward(SampleMultiScreen()) },
+        "Screen Effects" to { navigation?.forward(ScreenEffectsSampleScreen(i + 1)) },
+        "Dialogs & BottomSheets" to { navigation?.forward(DialogsPlayground(i + 1)) },
+        "Container" to { navigation?.forward(SampleContainerScreen(i + 1)) },
+        "Custom Container Actions" to { navigation?.forward(SampleCustomContainerScreen()) },
+        "Custom Container" to { navigation?.forward(RemovableItemContainerScreen()) },
+        "Horizontal Pager" to { navigation?.forward(HorizontalPagerScreen()) },
+        "Stacks in LazyColumn" to { navigation?.forward(StackInLazyColumnScreen()) },
+        "List/Details" to { navigation?.forward(ListScreen()) },
         // Just experiments
-//        "2 items screen" to { navigator.forward(TwoTopItemsStackScreen(i + 1)) },
-//                "Demo" to { navigator.forward(SaveableStateHolderDemoScreen()) },
-        "Sample Screen Model" to { navigator?.forward(ModelSampleScreen()) },
-        "Android ViewModel" to { navigator?.forward(AndroidViewModelSampleScreen(i + 1)) },
-        "Movable Content" to { navigator?.forward(MovableContentPlaygroundScreen()) },
-        "Animation Playground" to { navigator?.forward(AnimationPlaygroundScreen()) },
+//        "2 items screen" to { navigation.forward(TwoTopItemsStackScreen(i + 1)) },
+//                "Demo" to { navigation.forward(SaveableStateHolderDemoScreen()) },
+        "Sample Screen Model" to { navigation?.forward(ModelSampleScreen()) },
+        "Android ViewModel" to { navigation?.forward(AndroidViewModelSampleScreen(i + 1)) },
+        "Movable Content" to { navigation?.forward(MovableContentPlaygroundScreen()) },
+        "Animation Playground" to { navigation?.forward(AnimationPlaygroundScreen()) },
     ).let {
         ButtonsState(it)
     }

--- a/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/SampleCustomBottomSheet.kt
+++ b/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/SampleCustomBottomSheet.kt
@@ -9,12 +9,10 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import com.github.terrakok.modo.DialogScreen
 import com.github.terrakok.modo.ExperimentalModoApi
-import com.github.terrakok.modo.LocalContainerScreen
 import com.github.terrakok.modo.ScreenKey
 import com.github.terrakok.modo.generateScreenKey
-import com.github.terrakok.modo.stack.StackScreen
+import com.github.terrakok.modo.stack.LocalStackNavigation
 import com.github.terrakok.modo.stack.back
-import com.github.terrakok.modo.util.currentOrThrow
 import kotlinx.parcelize.Parcelize
 
 @OptIn(ExperimentalModoApi::class)
@@ -29,7 +27,7 @@ class SampleCustomBottomSheet(
     @OptIn(ExperimentalMaterialApi::class)
     @Composable
     override fun Content(modifier: Modifier) {
-        val navigation = LocalContainerScreen.currentOrThrow as StackScreen
+        val navigation = LocalStackNavigation.current
         val state = rememberModalBottomSheetState(initialValue = ModalBottomSheetValue.HalfExpanded)
         LaunchedEffect(key1 = state.currentValue) {
             if (state.currentValue == ModalBottomSheetValue.Hidden) {
@@ -38,7 +36,7 @@ class SampleCustomBottomSheet(
         }
         ModalBottomSheetLayout(
             sheetContent = {
-                MainScreenContent(i, screenKey, LocalContainerScreen.current as StackScreen, modifier)
+                MainScreenContent(i, screenKey, navigation, modifier)
             },
             sheetState = state
         ) {

--- a/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/SamplePermanentDialog.kt
+++ b/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/SamplePermanentDialog.kt
@@ -2,7 +2,6 @@ package com.github.terrakok.androidcomposeapp.screens
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -12,10 +11,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import com.github.terrakok.modo.DialogScreen
 import com.github.terrakok.modo.ExperimentalModoApi
-import com.github.terrakok.modo.LocalContainerScreen
 import com.github.terrakok.modo.ScreenKey
 import com.github.terrakok.modo.generateScreenKey
-import com.github.terrakok.modo.stack.StackScreen
+import com.github.terrakok.modo.stack.LocalStackNavigation
 import kotlinx.parcelize.Parcelize
 
 @OptIn(ExperimentalModoApi::class)
@@ -43,7 +41,7 @@ class SamplePermanentDialog(
                 .clip(RoundedCornerShape(16.dp))
                 .background(Color.White)
         ) {
-            MainScreenContent(i, screenKey, LocalContainerScreen.current as StackScreen, modifier)
+            MainScreenContent(i, screenKey, LocalStackNavigation.current, modifier)
         }
     }
 }

--- a/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/ScreenEffectsSampleScreen.kt
+++ b/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/ScreenEffectsSampleScreen.kt
@@ -15,14 +15,13 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import com.github.terrakok.androidcomposeapp.screens.base.SampleScreenContent
 import com.github.terrakok.modo.ExperimentalModoApi
-import com.github.terrakok.modo.LocalContainerScreen
 import com.github.terrakok.modo.Screen
 import com.github.terrakok.modo.ScreenKey
 import com.github.terrakok.modo.generateScreenKey
 import com.github.terrakok.modo.lifecycle.DisposableScreenEffect
 import com.github.terrakok.modo.lifecycle.LaunchedScreenEffect
 import com.github.terrakok.modo.lifecycle.LifecycleScreenEffect
-import com.github.terrakok.modo.stack.StackNavigationContainer
+import com.github.terrakok.modo.stack.LocalStackNavigation
 import com.github.terrakok.modo.stack.back
 import com.github.terrakok.modo.stack.forward
 import kotlinx.parcelize.Parcelize
@@ -57,7 +56,7 @@ class ScreenEffectsSampleScreen(
                 logcat { "Analytics: screen destroyed" }
             }
         }
-        val parent = LocalContainerScreen.current as StackNavigationContainer
+        val navigation = LocalStackNavigation.current
         SampleScreenContent(
             screenIndex = screenIndex,
             screenName = "ScreenEffectsSampleScreen",
@@ -67,8 +66,8 @@ class ScreenEffectsSampleScreen(
             ButtonsList(
                 buttonsState = remember {
                     listOf(
-                        "Forward" to { parent.forward(MainScreen(screenIndex + 1)) },
-                        "Back" to { parent.back() }
+                        "Forward" to { navigation.forward(MainScreen(screenIndex + 1)) },
+                        "Back" to { navigation.back() }
                     ).let {
                         ButtonsState(it)
                     }

--- a/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/containers/CustomAction.kt
+++ b/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/containers/CustomAction.kt
@@ -10,7 +10,7 @@ class AddTab(
 ) : MultiScreenReducerAction {
     override fun reduce(oldState: MultiScreenState): MultiScreenState {
         return MultiScreenState(
-            oldState.containers + SampleStack(rootScreen),
+            oldState.screens + SampleStack(rootScreen),
             oldState.selected
         )
     }

--- a/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/containers/SampleContainerScreen.kt
+++ b/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/containers/SampleContainerScreen.kt
@@ -20,12 +20,11 @@ import com.github.terrakok.androidcomposeapp.components.CancelButton
 import com.github.terrakok.androidcomposeapp.screens.MainScreen
 import com.github.terrakok.androidcomposeapp.screens.base.SampleScreenContent
 import com.github.terrakok.modo.ExperimentalModoApi
-import com.github.terrakok.modo.LocalContainerScreen
 import com.github.terrakok.modo.NavModel
 import com.github.terrakok.modo.lifecycle.LifecycleScreenEffect
 import com.github.terrakok.modo.model.OnScreenRemoved
+import com.github.terrakok.modo.stack.LocalStackNavigation
 import com.github.terrakok.modo.stack.StackNavModel
-import com.github.terrakok.modo.stack.StackScreen
 import com.github.terrakok.modo.stack.StackState
 import com.github.terrakok.modo.stack.back
 import kotlinx.parcelize.Parcelize
@@ -53,7 +52,7 @@ class SampleContainerScreen(
         OnScreenRemoved {
             logcat { "Screen $screenKey was removed" }
         }
-        val parent = LocalContainerScreen.current as StackScreen
+        val navigation = LocalStackNavigation.current
         Box {
             SampleScreenContent(
                 screenIndex = i,
@@ -72,7 +71,7 @@ class SampleContainerScreen(
                 modifier = Modifier
                     .align(Alignment.TopEnd)
                     .windowInsetsPadding(WindowInsets.statusBars),
-                onClick = { parent.back() },
+                onClick = { navigation.back() },
                 contentDescription = "Close screen"
             )
         }

--- a/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/containers/SampleMultiScreen.kt
+++ b/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/containers/SampleMultiScreen.kt
@@ -61,7 +61,7 @@ class SampleMultiScreen(
                     textAlign = TextAlign.Center,
                     text = "🪄"
                 )
-                repeat(navigationState.containers.size) { tabPos ->
+                repeat(navigationState.screens.size) { tabPos ->
                     Tab(
                         modifier = Modifier.weight(1f),
                         isSelected = navigationState.selected == tabPos,
@@ -71,7 +71,7 @@ class SampleMultiScreen(
                 }
                 Text(
                     modifier = Modifier
-                        .clickable { dispatch(AddTab(navigationState.containers.size.toString(), MainScreen(1))) }
+                        .clickable { dispatch(AddTab(navigationState.screens.size.toString(), MainScreen(1))) }
                         .padding(16.dp),
                     textAlign = TextAlign.Center,
                     text = "[+]"
@@ -84,7 +84,7 @@ class SampleMultiScreen(
     fun TopContent(showAllStacks: Boolean, modifier: Modifier) {
         Box(modifier = modifier) {
             Row {
-                for ((pos, container) in navigationState.containers.withIndex()) {
+                for ((pos, container) in navigationState.screens.withIndex()) {
                     if (showAllStacks || pos == navigationState.selected) {
                         Box(modifier = Modifier.weight(1f)) {
                             // внутри вызывается используется SaveableStateProvider с одинаковым ключом для экрана

--- a/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/containers/custom/InnerScreen.kt
+++ b/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/containers/custom/InnerScreen.kt
@@ -41,9 +41,9 @@ class InnerScreen(
     @OptIn(ExperimentalModoApi::class)
     @Composable
     override fun Content(modifier: Modifier) {
-        val parent = LocalContainerScreen.current
+        val parent = LocalSampleCustomNavigation.current
         val closeScreen by rememberUpdatedState {
-            (parent as? SampleCustomContainerScreen)?.dispatch(RemoveScreen(screenKey)) ?: Unit
+            parent.dispatch(RemoveScreen(screenKey))
         }
         LifecycleScreenEffect {
             LifecycleEventObserver { _, event ->

--- a/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/containers/custom/SampleCustomContainerScreen.kt
+++ b/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/containers/custom/SampleCustomContainerScreen.kt
@@ -15,7 +15,9 @@ import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.ProvidedValue
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.movableContentOf
 import androidx.compose.runtime.mutableStateMapOf
@@ -51,10 +53,17 @@ internal class RemoveScreen(val screenKey: ScreenKey) : CustomContainerReducerAc
     )
 }
 
+internal val LocalSampleCustomNavigation = compositionLocalOf<SampleCustomContainerScreen> {
+    error("CompositionLocal LocalSampleCustomNavigation is not present")
+}
+
 @Parcelize
 internal class SampleCustomContainerScreen(
     private val navModel: NavModel<CustomContainerState, CustomContainerAction> = NavModel(CustomContainerState(listOf(InnerScreen())))
 ) : ContainerScreen<CustomContainerState, CustomContainerAction>(navModel) {
+
+    override fun provideCompositionLocals(): Array<ProvidedValue<*>> =
+        arrayOf(LocalSampleCustomNavigation provides this)
 
     @OptIn(ExperimentalLayoutApi::class)
     @Composable

--- a/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/dialogs/DialogsPlayground.kt
+++ b/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/dialogs/DialogsPlayground.kt
@@ -7,11 +7,11 @@ import com.github.terrakok.androidcomposeapp.screens.ButtonsState
 import com.github.terrakok.androidcomposeapp.screens.MainScreen
 import com.github.terrakok.androidcomposeapp.screens.base.ButtonsScreenContent
 import com.github.terrakok.modo.ExperimentalModoApi
-import com.github.terrakok.modo.LocalContainerScreen
 import com.github.terrakok.modo.Screen
 import com.github.terrakok.modo.ScreenKey
 import com.github.terrakok.modo.generateScreenKey
-import com.github.terrakok.modo.stack.StackScreen
+import com.github.terrakok.modo.stack.LocalStackNavigation
+import com.github.terrakok.modo.stack.StackNavContainer
 import com.github.terrakok.modo.stack.forward
 import kotlinx.parcelize.Parcelize
 
@@ -32,7 +32,7 @@ internal fun DialogsPlaygroundContent(screenIndex: Int, screenKey: ScreenKey, mo
         screenIndex = screenIndex,
         screenName = "DialogsPlayground",
         screenKey = screenKey,
-        buttonsState = rememberDialogsButtons(LocalContainerScreen.current as StackScreen, screenIndex),
+        buttonsState = rememberDialogsButtons(LocalStackNavigation.current, screenIndex),
         modifier = modifier
     )
 }
@@ -40,15 +40,15 @@ internal fun DialogsPlaygroundContent(screenIndex: Int, screenKey: ScreenKey, mo
 @OptIn(ExperimentalModoApi::class)
 @Composable
 internal fun rememberDialogsButtons(
-    navigator: StackScreen,
+    navigation: StackNavContainer,
     i: Int
 ): ButtonsState =
     remember {
         listOf(
-            "Forward" to { navigator.forward(MainScreen(i + 1)) },
-            "Forward Dialogs" to { navigator.forward(DialogsPlayground(i + 1)) },
+            "Forward" to { navigation.forward(MainScreen(i + 1)) },
+            "Forward Dialogs" to { navigation.forward(DialogsPlayground(i + 1)) },
             "System Dialog" to {
-                navigator.forward(
+                navigation.forward(
                     SampleDialog(
                         i + 1,
                         dialogsPlayground = true,
@@ -58,7 +58,7 @@ internal fun rememberDialogsButtons(
                 )
             },
             "Custom Dialog" to {
-                navigator.forward(
+                navigation.forward(
                     SampleDialog(
                         i + 1,
                         dialogsPlayground = true,
@@ -68,7 +68,7 @@ internal fun rememberDialogsButtons(
                 )
             },
             "System Dialog perm" to {
-                navigator.forward(
+                navigation.forward(
                     SampleDialog(
                         i + 1,
                         dialogsPlayground = true,
@@ -78,7 +78,7 @@ internal fun rememberDialogsButtons(
                 )
             },
             "Custom Dialog perm" to {
-                navigator.forward(
+                navigation.forward(
                     SampleDialog(
                         i + 1,
                         dialogsPlayground = true,
@@ -87,19 +87,19 @@ internal fun rememberDialogsButtons(
                     )
                 )
             },
-            "System Dialog Stack" to { navigator.forward(SampleDialogWithStack(i + 1, systemDialog = true, permanentDialog = false)) },
-            "Custom Dialog Stack" to { navigator.forward(SampleDialogWithStack(i + 1, systemDialog = false, permanentDialog = false)) },
-            "System Dialog Stack perm" to { navigator.forward(SampleDialogWithStack(i + 1, systemDialog = true, permanentDialog = true)) },
-            "Custom Dialog Stack perm" to { navigator.forward(SampleDialogWithStack(i + 1, systemDialog = false, permanentDialog = true)) },
-            "System BS" to { navigator.forward(SampleBottomSheet(i + 1, systemDialog = true, permanentDialog = false)) },
-            "Custom BS" to { navigator.forward(SampleBottomSheet(i + 1, systemDialog = false, permanentDialog = false)) },
-            "System BS perm" to { navigator.forward(SampleBottomSheet(i + 1, systemDialog = true, permanentDialog = false)) },
-            "Custom BS perm" to { navigator.forward(SampleBottomSheet(i + 1, systemDialog = false, permanentDialog = false)) },
-            "System BS Stack" to { navigator.forward(SampleBottomSheetStack(i + 1, systemDialog = true, permanentDialog = false)) },
-            "Custom BS Stack" to { navigator.forward(SampleBottomSheetStack(i + 1, systemDialog = false, permanentDialog = false)) },
-            "System BS Stack perm" to { navigator.forward(SampleBottomSheetStack(i + 1, systemDialog = true, permanentDialog = false)) },
-            "Custom BS Stack perm" to { navigator.forward(SampleBottomSheetStack(i + 1, systemDialog = false, permanentDialog = false)) },
-            "System Dialog random dim" to { navigator.forward(SystemDialogWithCustomDimSample(i + 1)) },
+            "System Dialog Stack" to { navigation.forward(SampleDialogWithStack(i + 1, systemDialog = true, permanentDialog = false)) },
+            "Custom Dialog Stack" to { navigation.forward(SampleDialogWithStack(i + 1, systemDialog = false, permanentDialog = false)) },
+            "System Dialog Stack perm" to { navigation.forward(SampleDialogWithStack(i + 1, systemDialog = true, permanentDialog = true)) },
+            "Custom Dialog Stack perm" to { navigation.forward(SampleDialogWithStack(i + 1, systemDialog = false, permanentDialog = true)) },
+            "System BS" to { navigation.forward(SampleBottomSheet(i + 1, systemDialog = true, permanentDialog = false)) },
+            "Custom BS" to { navigation.forward(SampleBottomSheet(i + 1, systemDialog = false, permanentDialog = false)) },
+            "System BS perm" to { navigation.forward(SampleBottomSheet(i + 1, systemDialog = true, permanentDialog = false)) },
+            "Custom BS perm" to { navigation.forward(SampleBottomSheet(i + 1, systemDialog = false, permanentDialog = false)) },
+            "System BS Stack" to { navigation.forward(SampleBottomSheetStack(i + 1, systemDialog = true, permanentDialog = false)) },
+            "Custom BS Stack" to { navigation.forward(SampleBottomSheetStack(i + 1, systemDialog = false, permanentDialog = false)) },
+            "System BS Stack perm" to { navigation.forward(SampleBottomSheetStack(i + 1, systemDialog = true, permanentDialog = false)) },
+            "Custom BS Stack perm" to { navigation.forward(SampleBottomSheetStack(i + 1, systemDialog = false, permanentDialog = false)) },
+            "System Dialog random dim" to { navigation.forward(SystemDialogWithCustomDimSample(i + 1)) },
         ).let {
             ButtonsState(it)
         }

--- a/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/dialogs/SampleBottomSheet.kt
+++ b/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/dialogs/SampleBottomSheet.kt
@@ -12,12 +12,10 @@ import androidx.compose.ui.window.DialogProperties
 import com.github.terrakok.androidcomposeapp.screens.MainScreenContent
 import com.github.terrakok.modo.DialogScreen
 import com.github.terrakok.modo.ExperimentalModoApi
-import com.github.terrakok.modo.LocalContainerScreen
 import com.github.terrakok.modo.ScreenKey
 import com.github.terrakok.modo.generateScreenKey
-import com.github.terrakok.modo.stack.StackScreen
+import com.github.terrakok.modo.stack.LocalStackNavigation
 import com.github.terrakok.modo.stack.back
-import com.github.terrakok.modo.util.currentOrThrow
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -48,7 +46,7 @@ class SampleBottomSheet(
     @Composable
     override fun Content(modifier: Modifier) {
         SetupSystemBar()
-        val navigation = LocalContainerScreen.currentOrThrow as StackScreen
+        val navigation = LocalStackNavigation.current
         val state = rememberModalBottomSheetState(initialValue = ModalBottomSheetValue.HalfExpanded)
         LaunchedEffect(key1 = state.currentValue) {
             if (state.currentValue == ModalBottomSheetValue.Hidden) {
@@ -60,7 +58,7 @@ class SampleBottomSheet(
                 MainScreenContent(
                     screenIndex = i,
                     screenKey = screenKey,
-                    parent = LocalContainerScreen.current as StackScreen,
+                    navigation = navigation,
                     modifier = Modifier.fillMaxSize()
                 )
             },

--- a/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/dialogs/SampleDialog.kt
+++ b/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/dialogs/SampleDialog.kt
@@ -25,6 +25,7 @@ import com.github.terrakok.modo.LocalContainerScreen
 import com.github.terrakok.modo.ScreenKey
 import com.github.terrakok.modo.generateScreenKey
 import com.github.terrakok.modo.lifecycle.LifecycleScreenEffect
+import com.github.terrakok.modo.stack.LocalStackNavigation
 import com.github.terrakok.modo.stack.StackScreen
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
@@ -64,7 +65,7 @@ class SampleDialog(
                 logcat(tag = "SampleDialog") { "$screenKey $event" }
             }
         }
-        val container = LocalContainerScreen.current as StackScreen
+        val navigation = LocalStackNavigation.current
         if (systemDialog) {
             Box(
                 modifier
@@ -74,7 +75,7 @@ class SampleDialog(
                 if (dialogsPlayground) {
                     DialogsPlaygroundContent(screenIndex, screenKey)
                 } else {
-                    MainScreenContent(screenIndex, screenKey, container)
+                    MainScreenContent(screenIndex, screenKey, navigation)
                 }
             }
         } else {

--- a/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/stack/StackActionsScreen.kt
+++ b/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/stack/StackActionsScreen.kt
@@ -12,13 +12,13 @@ import com.github.terrakok.androidcomposeapp.screens.base.ButtonsScreenContent
 import com.github.terrakok.androidcomposeapp.screens.dialogs.SampleBottomSheetStack
 import com.github.terrakok.androidcomposeapp.screens.dialogs.SampleDialog
 import com.github.terrakok.androidcomposeapp.screens.dialogs.SampleDialogWithStack
-import com.github.terrakok.modo.LocalContainerScreen
 import com.github.terrakok.modo.Screen
 import com.github.terrakok.modo.ScreenKey
 import com.github.terrakok.modo.generateScreenKey
 import com.github.terrakok.modo.stack.Back
 import com.github.terrakok.modo.stack.Forward
-import com.github.terrakok.modo.stack.StackNavigationContainer
+import com.github.terrakok.modo.stack.LocalStackNavigation
+import com.github.terrakok.modo.stack.StackNavContainer
 import com.github.terrakok.modo.stack.StackState
 import com.github.terrakok.modo.stack.back
 import com.github.terrakok.modo.stack.backTo
@@ -45,7 +45,7 @@ class StackActionsScreen(
             screenKey = screenKey,
             screenIndex = screenIndex,
             buttonsState = rememberButtons(
-                LocalContainerScreen.current as StackNavigationContainer,
+                LocalStackNavigation.current,
                 screenIndex
             )
         )
@@ -54,57 +54,57 @@ class StackActionsScreen(
 
 @Composable
 private fun rememberButtons(
-    navigator: StackNavigationContainer,
+    navigation: StackNavContainer,
     screenIndex: Int
 ): ButtonsState {
     val coroutineScope = rememberCoroutineScope()
     return remember {
         listOf<Pair<String, () -> Unit>>(
-            "Forward" to { navigator.forward(StackActionsScreen(screenIndex + 1)) },
-            "Back" to { navigator.back() },
-            "Replace" to { navigator.replace(StackActionsScreen(screenIndex + 1)) },
+            "Forward" to { navigation.forward(StackActionsScreen(screenIndex + 1)) },
+            "Back" to { navigation.back() },
+            "Replace" to { navigation.replace(StackActionsScreen(screenIndex + 1)) },
             "New stack" to {
-                navigator.newStack(
+                navigation.newStack(
                     StackActionsScreen(screenIndex + 1),
                     StackActionsScreen(screenIndex + 2),
                     StackActionsScreen(screenIndex + 3)
                 )
             },
             "Multi forward" to {
-                navigator.forward(
+                navigation.forward(
                     StackActionsScreen(screenIndex + 1),
                     StackActionsScreen(screenIndex + 2),
                     StackActionsScreen(screenIndex + 3)
                 )
             },
-            "New root" to { navigator.newStack(StackActionsScreen(screenIndex + 1)) },
+            "New root" to { navigation.newStack(StackActionsScreen(screenIndex + 1)) },
             "Forward 3 sec delay" to {
                 coroutineScope.launch {
                     delay(3000)
-                    navigator.forward(StackActionsScreen(screenIndex + 1))
+                    navigation.forward(StackActionsScreen(screenIndex + 1))
                 }
             },
             "Remove previous" to {
-                val prevScreenIndex = navigator.navigationState.stack.lastIndex - 1
-                navigator.removeScreens { pos, screen -> pos == prevScreenIndex }
+                val prevScreenIndex = navigation.navigationState.stack.lastIndex - 1
+                navigation.removeScreens { pos, screen -> pos == prevScreenIndex }
             },
             "Back to '3'" to {
-                navigator.backTo { pos, _ -> pos == 2 }
+                navigation.backTo { pos, _ -> pos == 2 }
             },
             "Back 2 screens + Forward" to {
-                navigator.dispatch(
+                navigation.dispatch(
                     Back(2),
                     Forward(StackActionsScreen(screenIndex + 1))
                 )
             },
             "Back to MainScreen" to {
-                navigator.backTo<MainScreen>()
+                navigation.backTo<MainScreen>()
             },
             "Back to root" to {
-                navigator.backTo { pos, _ -> pos == 0 }
+                navigation.backTo { pos, _ -> pos == 0 }
             },
             "Custom action" to {
-                navigator.dispatch { oldState ->
+                navigation.dispatch { oldState ->
                     StackState(
                         oldState.stack.filterIndexed { index, screen ->
                             index % 2 == 0 && screen != oldState.stack.last()
@@ -115,11 +115,20 @@ private fun rememberButtons(
             // Just experiments
 //        "2 items screen" to { navigator.forward(TwoTopItemsStackScreen(screenIndex + 1)) },
 //                "Demo" to { navigator.forward(SaveableStateHolderDemoScreen()) },
-            "Dialog" to { navigator.forward(SampleDialog(screenIndex + 1, dialogsPlayground = false, systemDialog = true, permanentDialog = false)) },
-            "Permanent Dialog" to { navigator.forward(SamplePermanentDialog(screenIndex + 1)) },
-            "Dialog Container" to { navigator.forward(SampleDialogWithStack(screenIndex + 1)) },
-            "Bottom Sheet" to { navigator.forward(SampleBottomSheetStack(screenIndex + 1)) },
-            "Custom Bottom Sheet" to { navigator.forward(SampleCustomBottomSheet(screenIndex + 1)) },
+            "Dialog" to {
+                navigation.forward(
+                    SampleDialog(
+                        screenIndex + 1,
+                        dialogsPlayground = false,
+                        systemDialog = true,
+                        permanentDialog = false
+                    )
+                )
+            },
+            "Permanent Dialog" to { navigation.forward(SamplePermanentDialog(screenIndex + 1)) },
+            "Dialog Container" to { navigation.forward(SampleDialogWithStack(screenIndex + 1)) },
+            "Bottom Sheet" to { navigation.forward(SampleBottomSheetStack(screenIndex + 1)) },
+            "Custom Bottom Sheet" to { navigation.forward(SampleCustomBottomSheet(screenIndex + 1)) },
         ).let {
             ButtonsState(it)
         }

--- a/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/viewmodel/AndroidViewModelSampleScreen.kt
+++ b/sample/src/main/java/com/github/terrakok/androidcomposeapp/screens/viewmodel/AndroidViewModelSampleScreen.kt
@@ -13,12 +13,11 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.terrakok.androidcomposeapp.screens.MainScreenContent
 import com.github.terrakok.modo.ExperimentalModoApi
-import com.github.terrakok.modo.LocalContainerScreen
 import com.github.terrakok.modo.Screen
 import com.github.terrakok.modo.ScreenKey
 import com.github.terrakok.modo.generateScreenKey
 import com.github.terrakok.modo.lifecycle.LifecycleScreenEffect
-import com.github.terrakok.modo.stack.StackScreen
+import com.github.terrakok.modo.stack.LocalStackNavigation
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.isActive
@@ -81,8 +80,7 @@ internal class AndroidViewModelSampleScreen(
         val viewModel: SampleViewModel = viewModel {
             SampleViewModel(screenPos, createSavedStateHandle())
         }
-        val parent = LocalContainerScreen.current
-        MainScreenContent(screenPos, screenKey, viewModel.stateFlow.collectAsState().value, parent as StackScreen, modifier)
+        MainScreenContent(screenPos, screenKey, viewModel.stateFlow.collectAsState().value, LocalStackNavigation.current, modifier)
     }
 
 }


### PR DESCRIPTION
* Added Composition Locals for stack and multiscreen. `LocalStackNavigation` and `LocalMultiScreenNavigation`
* Changed MultiScreen api: now it contains list of `Screen`, but no `ContainerScreen<*, *>` 
* Made RootScreen implement `ContainerScreen` to be able to use any screen as a root, but not only stack or something else
* Added `provideCompositionLocal ` and `provideNavigationContainer` to container screen for easy providing composition local, contains this specific screen to hierarchy 