### PR TITLE
Fixed crush for replace command. Covered with tests. Introduced including param for BackTo action.

### DIFF
--- a/modo-compose/build.gradle.kts
+++ b/modo-compose/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
 //    implementation("org.jetbrains.kotlin:kotlin-parcelize-runtime:${properties["version.kotlin"]}")
 
     testImplementation(libs.test.junit.jupiter)
+    testImplementation(kotlin("test"))
 }
 
 tasks.withType(Test::class) {

--- a/modo-compose/src/test/java/com/github/terrakok/modo/MockScreen.kt
+++ b/modo-compose/src/test/java/com/github/terrakok/modo/MockScreen.kt
@@ -6,7 +6,7 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 class MockScreen(
-    override val screenKey: ScreenKey
+    override val screenKey: ScreenKey = generateScreenKey()
 ) : Screen {
 
     @Composable

--- a/modo-compose/src/test/java/com/github/terrakok/modo/stack/BackToTest.kt
+++ b/modo-compose/src/test/java/com/github/terrakok/modo/stack/BackToTest.kt
@@ -1,0 +1,96 @@
+package com.github.terrakok.modo.stack
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.github.terrakok.modo.MockScreen
+import com.github.terrakok.modo.Screen
+import com.github.terrakok.modo.ScreenKey
+import com.github.terrakok.modo.generateScreenKey
+import kotlinx.parcelize.Parcelize
+import org.junit.jupiter.api.Assertions.assertEquals
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+
+class BackToTest {
+
+    @Test
+    fun `When back to condition always false - Then stack not changed`() {
+        val oldState = StackState(listOf(MockScreen(), MockScreen()))
+        val action = BackTo { _, _ -> false }
+
+        val newState = action.reduce(oldState)
+
+        assertEquals(oldState, newState)
+    }
+
+    @Test
+    fun `When including and back to condition always false - Then stack not changed`() {
+        val oldState = StackState(listOf(MockScreen(), MockScreen()))
+        val action = BackTo(including = true) { _, _ -> false }
+
+        val newState = action.reduce(oldState)
+
+        assertEquals(oldState, newState)
+    }
+
+    @Test
+    fun `When back to first including - Then stack is empty`() {
+        val oldState = StackState(listOf(MockScreen(), MockScreen()))
+        val action = BackTo(including = true) { pos, _ -> pos == 0 }
+
+        val newState = action.reduce(oldState)
+
+        assertEquals(StackState(emptyList()), newState)
+    }
+
+    @Test
+    fun `When back to AnotherMockScreen when it on the top - Then no changes`() {
+        val oldState = StackState(listOf(MockScreen(), AnotherMockScreen(), AnotherMockScreen()))
+        val action = BackTo<AnotherMockScreen>()
+
+        val newState = action.reduce(oldState)
+
+        assertEquals(oldState, newState)
+    }
+
+    @Test
+    fun `When back to AnotherMockScreen when it on the top and including - Then remove last screen`() {
+        val oldStack = listOf(MockScreen(), AnotherMockScreen(), AnotherMockScreen())
+        val oldState = StackState(oldStack)
+        val action = BackTo<AnotherMockScreen>(including = true)
+
+        val newState = action.reduce(oldState)
+
+        assertContentEquals(oldStack.dropLast(1), newState.stack)
+    }
+
+    @Test
+    fun `When back to on empty stack - Then no changes`() {
+        val oldState = StackState(emptyList())
+        val action = BackTo<AnotherMockScreen>()
+
+        val newState = action.reduce(oldState)
+
+        assertEquals(oldState, newState)
+    }
+
+    @Test
+    fun `When back to on empty stack including - Then no changes`() {
+        val oldState = StackState(emptyList())
+        val action = BackTo<AnotherMockScreen>(including = true)
+
+        val newState = action.reduce(oldState)
+
+        assertEquals(oldState, newState)
+    }
+
+    @Parcelize
+    class AnotherMockScreen(
+        override val screenKey: ScreenKey = generateScreenKey()
+    ) : Screen {
+
+        @Composable
+        override fun Content(modifier: Modifier) = Unit
+    }
+
+}

--- a/modo-compose/src/test/java/com/github/terrakok/modo/stack/ReplaceTest.kt
+++ b/modo-compose/src/test/java/com/github/terrakok/modo/stack/ReplaceTest.kt
@@ -1,0 +1,33 @@
+package com.github.terrakok.modo.stack
+
+import com.github.terrakok.modo.MockScreen
+import com.github.terrakok.modo.ScreenKey
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+
+class ReplaceTest {
+
+    @Test
+    fun `When replace empty stack - Then stack contains provided screen`() {
+        val oldState = StackState(emptyList())
+        val newScreen = MockScreen()
+        val action = Replace(newScreen)
+
+        val newState = action.reduce(oldState)
+
+        assertContentEquals(expected = listOf(newScreen), actual = newState.stack)
+    }
+
+    @Test
+    fun `When replace non-empty stack - Then stack contains provided screen`() {
+        val oldState = StackState(listOf(MockScreen()))
+        val newScreen1 = MockScreen(ScreenKey("1"))
+        val newScreen2 = MockScreen(ScreenKey("2"))
+        val action = Replace(newScreen1, newScreen2)
+
+        val newState = action.reduce(oldState)
+
+        assertContentEquals(expected = listOf(newScreen1, newScreen2), actual = newState.stack)
+    }
+
+}


### PR DESCRIPTION
Fix of #53 