### PR TITLE
Fixed order of start events

### DIFF
--- a/TestInstructions.md
+++ b/TestInstructions.md
@@ -12,3 +12,6 @@ certain cases:
     * Check pause, stop. dispose - 2 fast back or replace
     * Check create, start, resume - 2 fast forward or replace
 * Movable content test
+* Check lifecycle order in nested screens when activity/fragment recreated, by rotating the screen. Following rules should be applied:
+    * Parent screens events ON_CREATE, ON_START, ON_RESUME should be called before child screens events
+    * Parent screens events ON_PAUSE, ON_STOP, ON_DESTROY should be called after child screens events

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 leakcanaryAndroid = "2.14"
-modo = "0.10.0-alpha1"
+modo = "0.10.0-alpha2"
 androidGradlePlugin = "8.4.0"
 detektComposeVersion = "0.3.20"
 detektVersion = "1.23.6"

--- a/modo-compose/src/main/java/com/github/terrakok/modo/android/ModoScreenAndroidAdapter.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/android/ModoScreenAndroidAdapter.kt
@@ -219,6 +219,11 @@ class ModoScreenAndroidAdapter private constructor(
             onCreate(savedState) // do this in the UI thread to force it to be called before anything else
         }
 
+        DisposableEffect(this) {
+            emitOnStartEvents()
+            onDispose { }
+        }
+
         content()
 
         DisposableEffect(this) {
@@ -245,8 +250,6 @@ class ModoScreenAndroidAdapter private constructor(
                     lifecycle.safeHandleLifecycleEvent(event)
                 }
             }
-
-            emitOnStartEvents()
 
             onDispose {
 //                Log.d("LifecycleDebug", "ModoScreenAndroidAdapter registerParentLifecycleListener onDispose ${screen.screenKey}")

--- a/modo-compose/src/main/java/com/github/terrakok/modo/stack/StackScreen.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/stack/StackScreen.kt
@@ -72,6 +72,8 @@ abstract class StackScreen(
         dialogModifier: Modifier = Modifier,
         content: RendererContent<StackState> = defaultRendererContent
     ) {
+        StackBackHandler()
+
         val screensToRender: ScreensToRender by rememberScreensToRender()
         screensToRender.screen?.let { screen ->
             Content(screen, modifier, content)
@@ -132,6 +134,18 @@ abstract class StackScreen(
     }
 
     @Composable
+    private fun StackBackHandler() {
+        val isBackHandlerEnabled by remember {
+            derivedStateOf {
+                defaultBackHandler && navigationState.getChildScreens().size > 1
+            }
+        }
+        BackHandler(enabled = isBackHandlerEnabled) {
+            back()
+        }
+    }
+
+    @Composable
     @OptIn(ExperimentalModoApi::class)
     private fun StackScreen.RenderDialog(
         dialog: DialogScreen,
@@ -174,14 +188,6 @@ abstract class StackScreen(
         modifier: Modifier = Modifier,
         content: RendererContent<StackState> = defaultRendererContent
     ) {
-        val isBackHandlerEnabled by remember {
-            derivedStateOf {
-                defaultBackHandler && navigationState.getChildScreens().size > 1
-            }
-        }
-        BackHandler(enabled = isBackHandlerEnabled) {
-            back()
-        }
         super.InternalContent(screen, modifier, content)
     }
 


### PR DESCRIPTION
Now parent start and resume happens before child. Also, it fixed back handling after activity recreation.