### PR TITLE
Fixed resumed child when parent is not resumed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [Modo](https://ikarenkov.github.io/Modo) - State-Based Jetpack Compose Navigation
 
-[![Maven Central latest stable](https://img.shields.io/maven-central/v/com.github.terrakok/modo-compose?versionSuffix=0.10.0&label=Latest%20stable&color=28A745)](https://central.sonatype.com/artifact/com.github.terrakok/modo-compose/0.10.0/overview)
+[![Maven Central latest stable](https://img.shields.io/maven-central/v/com.github.terrakok/modo-compose?versionSuffix=0.10.1&label=Latest%20stable&color=28A745)](https://central.sonatype.com/artifact/com.github.terrakok/modo-compose/0.10.1/overview)
 [![Maven Central latest](https://img.shields.io/maven-central/v/com.github.terrakok/modo-compose?label=Latest&color=FFA500)](https://central.sonatype.com/artifact/com.github.terrakok/modo-compose)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 

--- a/Writerside/modo-docs.tree
+++ b/Writerside/modo-docs.tree
@@ -14,6 +14,7 @@
         <toc-element topic="Screen-effects.md" />
         <toc-element topic="Modo-and-DI.md" />
         <toc-element topic="Android-integrations.md" />
+        <toc-element topic="Lifecycle.md"/>
     </toc-element>
     <toc-element topic="Community-and-contribution.md" />
 </instance-profile>

--- a/Writerside/topics/Android-integrations.md
+++ b/Writerside/topics/Android-integrations.md
@@ -6,33 +6,12 @@ and `LocalSavedStateRegistryOwner`. This allows you to use functions like `viewM
 > [Sample code](%github_code_url%sample/src/main/java/com/github/terrakok/modo/sample/screens/viewmodel/AndroidViewModelSampleScreen.kt) demonstrating
 > Android integration inside a Modo Screen.
 
-## Lifecycle
-
-Since Modo provides Lifecycle support, let's take a look at what specific lifecycle events mean in the context of Screen Lifecycle:
-
-* `Lifecycle.Event.ON_CREATE` - called once per screen when the screen is created.
-* `Lifecycle.Event.ON_START` and `Lifecycle.Event.ON_RESUME` - dispatched when `Screen.Content` is composed for the first time.
-* `Lifecycle.Event.ON_PAUSE` and `Lifecycle.Event.ON_STOP` - dispatched when `Screen.Content` leaves the composition.
-* `Lifecycle.Event.ON_DESTROY` - called once per screen when it is removed from the navigation graph.
-
-For correctly handling `Lifecycle.Event` from your `Screen.Content`, we recommend using the built-in [screen effects](Screen-effects.md).
-The `LifecycleScreenEffect` is a convenient way to subscribe to a screen's Lifecycle.
-
-```kotlin
-LifecycleScreenEffect {
-    LifecycleEventObserver { _, event ->
-        logcat { "Lifecycle event $event." }
-    }
-}
-```
-
-> If you use `LaunchedEffect` or `DisposableEffect` to subscribe to the screen's Lifecycle, you won't receive `Lifecycle.Event.ON_DESTROY` because
-> this event happens after the screen leaves the composition.
-
-{ style="warning" }
-
 ## ViewModel
 
 You can use functions provided by Jetpack Compose to get a `ViewModel`.
 
 <include from="snippets.topic" element-id="under_develop_note"/>
+
+## Lifecycle
+
+Moved to [Lifecycle](Lifecycle.md).

--- a/Writerside/topics/Lifecycle.md
+++ b/Writerside/topics/Lifecycle.md
@@ -1,0 +1,140 @@
+# Lifecycle
+
+This article covers the lifetime of screen instances and their integration with Android Lifecycle.
+
+## Screen instance lifecycle
+
+It is guaranteed that the screen instance lifetime is equal to application (process) lifetime, when you provide Modo integration using built-in
+function from `Modo`, such as`Modo.rememberRootScreen`. No matter how many times a screen is recomposed, activity or/and fragment is recreated etc.
+
+## Android Lifecycle
+
+Modo provides Android Lifecycle integration for your screens.
+You can use `LocalLifecycleOwner` inside  `Screen.Content` to access the lifecycle of a screen.
+It will return the nearest Screen's lifecycle owner.
+
+```kotlin
+class SampleScreen : Screen {
+    override fun Content(modifier: Modifier) {
+        val lifecycleOwner = LocalLifecycleOwner.current
+        // Use lifecycleOwner to observe lifecycle events
+    }
+}
+```
+
+### Lifecycle states and events
+
+Let's take a look at what specific lifecycle states mean in the context of Screen Lifecycle:
+
+<table>
+    <tr>
+        <th>State</th>
+        <th>Meaning</th>
+    </tr>
+    <tr>
+        <td><b>INITIALIZED</b></td>
+        <td>Screen is constructed (instance created), but it has never been displayed.</td>
+    </tr>
+    <tr>
+        <td><b>CREATED</b></td>
+        <td>
+
+Screen is in navigation hierarchy, it can be reached from RootScreen, that is integrated to Activity/Fragment. With other words, it was displayed at
+least once.
+
+</td>
+    </tr>
+    <tr>
+        <td><b>STARTED</b></td>
+        <td>
+
+`Screen.Content` is in composition.
+
+</td>
+    </tr>
+    <tr>
+        <td><b>RESUMED</b></td>
+        <td>
+
+**STARTED** and there is no unfinished transitions for this screen or it's parent.
+</td>
+    </tr>
+    <tr>
+        <td><b>DESTROYED</b></td>
+        <td>Screen is removed from the navigation graph.</td>
+    </tr>
+</table>
+
+To clarify, let's take a look at the lifecycle events:
+
+* `ON_CREATE` and `ON_DESTROY` are dispatched once per screen instance.
+
+### Screen transitions and lifecycle
+
+Modo provides convenient way to determine whenever screen's appearing/disappearing transitions are started or finished. To observe these events, you
+can rely on `ON_RESUME` and `ON_PAUSE` lifecycle events, check out the table
+
+<table>
+    <tr>
+        <th>Event</th>
+        <th>With transition</th>
+        <th>Without transition</th>
+    </tr>
+    <tr>
+        <td><b>ON_RESUME</b></td>
+        <td>
+
+Dispatched when as soon as there are no unfinished transitions for this screen and parent is in `State.RESUMED`.
+</td>
+        <td>
+
+Parent is `RESUMED`
+</td>
+    </tr>
+    <tr>
+        <td><b>ON_PAUSE</b></td>
+        <td>
+Dispatched when hiding transition is started.
+</td>
+        <td>
+
+Dispatched right before `ON_STOP`.
+</td>
+    </tr>
+</table>
+
+### Parent-Child Lifecycle propagation
+
+There is a set of rules between lifecycle of parent and child screens, which allows you to relay on your screen's lifecycle and don't worry about
+parent's lifecycle:
+
+1. Screen's `Lifecycle.State` is always lower or equal (<=) than the state of its parent.
+2. If child's lifecycle is ready to be in `RESUMED` state, it is not resumed until parent's lifecycle is `RESUMED` too.
+3. When screen`s lifecycle is moved down, it also moves children lifecycle to the same state.
+4. When screen's lifecycle is `RESUMED` and children's lifecycle is ready to be resumed, children's lifecycle is resumed too.
+
+Practical example of this is using events `ON_RESUME` and `ON_PAUSE` to show and hide keyboard:
+
+```kotlin
+val lifecycleOwner = LocalLifecycleOwner.current
+val keyboardController = LocalSoftwareKeyboardController.current
+DisposableEffect(this) {
+    val observer = LifecycleEventObserver { _, event ->
+        when (event) {
+            Lifecycle.Event.ON_RESUME -> {
+                focusRequester.requestFocus()
+            }
+            Lifecycle.Event.ON_PAUSE -> {
+                focusRequester.freeFocus()
+                keyboardController?.hide()
+            }
+            else -> {}
+        }
+    }
+    lifecycleOwner.lifecycle.addObserver(observer)
+    onDispose {
+        lifecycleOwner.lifecycle.removeObserver(observer)
+    }
+}
+TextField(text, setText, modifier = Modifier.focusRequester(focusRequester))
+```

--- a/Writerside/topics/Lifecycle.md
+++ b/Writerside/topics/Lifecycle.md
@@ -1,17 +1,19 @@
 # Lifecycle
 
-This article covers the lifetime of screen instances and their integration with Android Lifecycle.
+This article covers the lifetime of screen instances and their integration with the Android Lifecycle.
 
-## Screen instance lifecycle
+## Screen Instance Lifecycle
 
-It is guaranteed that the screen instance lifetime is equal to application (process) lifetime, when you provide Modo integration using built-in
-function from `Modo`, such as`Modo.rememberRootScreen`. No matter how many times a screen is recomposed, activity or/and fragment is recreated etc.
+The lifetime of a screen instance is guaranteed to match the application (process) lifetime when you integrate Modo using built-in functions such as
+`Modo.rememberRootScreen`. Regardless of how many times a screen is recomposed, or whether the activity and/or fragment is recreated, the screen
+instance remains consistent. This allows you to safely inject the screen instance into your DI container.
 
-## Android Lifecycle
+## Android Lifecycle Integration
 
-Modo provides Android Lifecycle integration for your screens.
-You can use `LocalLifecycleOwner` inside  `Screen.Content` to access the lifecycle of a screen.
-It will return the nearest Screen's lifecycle owner.
+Modo provides seamless [integration](%github_code_url%/modo-compose/src/main/java/com/github/terrakok/modo/android/ModoScreenAndroidAdapter.kt)
+with a Android Lifecycle for your screens.
+
+You can use `LocalLifecycleOwner` inside `Screen.Content` to access the lifecycle of a screen. This will return the nearest screen's lifecycle owner.
 
 ```kotlin
 class SampleScreen : Screen {
@@ -22,98 +24,46 @@ class SampleScreen : Screen {
 }
 ```
 
-### Lifecycle states and events
+### Lifecycle States and Events
 
-Let's take a look at what specific lifecycle states mean in the context of Screen Lifecycle:
+Here’s an overview of lifecycle states and their meanings in the context of the screen lifecycle:
 
-<table>
-    <tr>
-        <th>State</th>
-        <th>Meaning</th>
-    </tr>
-    <tr>
-        <td><b>INITIALIZED</b></td>
-        <td>Screen is constructed (instance created), but it has never been displayed.</td>
-    </tr>
-    <tr>
-        <td><b>CREATED</b></td>
-        <td>
+| **State**       | **Meaning**                                                                                                                 |
+|-----------------|-----------------------------------------------------------------------------------------------------------------------------|
+| **INITIALIZED** | The screen is constructed (instance created) but has never been displayed.                                                  |
+| **CREATED**     | The screen is in the navigation hierarchy and can be reached from the `RootScreen` integrated with an Activity or Fragment. |
+| **STARTED**     | `Screen.Content` is in composition.                                                                                         |
+| **RESUMED**     | The screen is **STARTED**, and there are no unfinished transitions for this screen or its parent.                           |
+| **DESTROYED**   | The screen is removed from the navigation graph.                                                                            |
 
-Screen is in navigation hierarchy, it can be reached from RootScreen, that is integrated to Activity/Fragment. With other words, it was displayed at
-least once.
+> `ON_CREATE` and `ON_DESTROY` are dispatched once per screen instance.
 
-</td>
-    </tr>
-    <tr>
-        <td><b>STARTED</b></td>
-        <td>
+### Screen Transitions and Lifecycle
 
-`Screen.Content` is in composition.
+Modo provides a convenient way to track when screen transitions start and finish. These events are tied to the `ON_RESUME` and `ON_PAUSE` lifecycle
+events. Here’s a summary:
 
-</td>
-    </tr>
-    <tr>
-        <td><b>RESUMED</b></td>
-        <td>
+| **Event**     | **With Transition**                                                                            | **Without Transition**                      |
+|---------------|------------------------------------------------------------------------------------------------|---------------------------------------------|
+| **ON_RESUME** | Dispatched when there are no unfinished transitions, and the parent is in the `RESUMED` state. | Dispatched when the parent is in `RESUMED`. |
+| **ON_PAUSE**  | Dispatched when a hiding transition starts.                                                    | Dispatched immediately before `ON_STOP`.    |
 
-**STARTED** and there is no unfinished transitions for this screen or it's parent.
-</td>
-    </tr>
-    <tr>
-        <td><b>DESTROYED</b></td>
-        <td>Screen is removed from the navigation graph.</td>
-    </tr>
-</table>
+### Parent-Child Lifecycle Propagation
 
-To clarify, let's take a look at the lifecycle events:
+The lifecycle of parent and child screens follows a set of rules, ensuring consistency and predictability:
 
-* `ON_CREATE` and `ON_DESTROY` are dispatched once per screen instance.
+1. A screen's `Lifecycle.State` is always less than or equal to (`<=`) its parent's state.
+2. A child screen is not moved to the `RESUMED` state until its parent is also in the `RESUMED` state.
+3. When a screen's lifecycle state is downgraded, its child screens are also moved to the same state.
+4. When a screen reaches the `RESUMED` state and its child screens are ready to resume, the children's lifecycles are also moved to `RESUMED`.
 
-### Screen transitions and lifecycle
+### Practical Example: Keyboard Management
 
-Modo provides convenient way to determine whenever screen's appearing/disappearing transitions are started or finished. To observe these events, you
-can rely on `ON_RESUME` and `ON_PAUSE` lifecycle events, check out the table
+A practical use case for these lifecycle events is managing the keyboard. For example, you can show and hide the keyboard using `ON_RESUME` and
+`ON_PAUSE` events:
 
-<table>
-    <tr>
-        <th>Event</th>
-        <th>With transition</th>
-        <th>Without transition</th>
-    </tr>
-    <tr>
-        <td><b>ON_RESUME</b></td>
-        <td>
-
-Dispatched when as soon as there are no unfinished transitions for this screen and parent is in `State.RESUMED`.
-</td>
-        <td>
-
-Parent is `RESUMED`
-</td>
-    </tr>
-    <tr>
-        <td><b>ON_PAUSE</b></td>
-        <td>
-Dispatched when hiding transition is started.
-</td>
-        <td>
-
-Dispatched right before `ON_STOP`.
-</td>
-    </tr>
-</table>
-
-### Parent-Child Lifecycle propagation
-
-There is a set of rules between lifecycle of parent and child screens, which allows you to relay on your screen's lifecycle and don't worry about
-parent's lifecycle:
-
-1. Screen's `Lifecycle.State` is always lower or equal (<=) than the state of its parent.
-2. If child's lifecycle is ready to be in `RESUMED` state, it is not resumed until parent's lifecycle is `RESUMED` too.
-3. When screen`s lifecycle is moved down, it also moves children lifecycle to the same state.
-4. When screen's lifecycle is `RESUMED` and children's lifecycle is ready to be resumed, children's lifecycle is resumed too.
-
-Practical example of this is using events `ON_RESUME` and `ON_PAUSE` to show and hide keyboard:
+* `ON_RESUME` indicates that the screen is ready for user input (transitions are finished)
+* `ON_PAUSE` indicates that the screen is not ready for user input (transitions are starting)
 
 ```kotlin
 val lifecycleOwner = LocalLifecycleOwner.current

--- a/build-logic/convention/src/main/kotlin/com/github/terrakok/DetektPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/github/terrakok/DetektPlugin.kt
@@ -26,49 +26,57 @@ class DetektPlugin : Plugin<Project> {
 
 fun Project.setupDetektTask() {
     tasks.register<Detekt>("detektAll") {
-        reports {
-            sarif.required = true
-        }
-        // The directories where detekt looks for source files.
-        // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.
-        setSource(projectDir)
+        configureDetekt(this)
+    }
+    tasks.register<Detekt>("detektFormat") {
+        configureDetekt(this)
+        autoCorrect = true
+    }
+}
 
-        include("**/*.kt")
-        include("**/*.kts")
-        exclude("**/resources/")
-        exclude("**/build/")
-        exclude("Writerside/codeSnippets/")
+private fun Project.configureDetekt(detekt: Detekt) {
+    detekt.reports {
+        sarif.required = true
+    }
+    // The directories where detekt looks for source files.
+    // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.
+    detekt.setSource(project.projectDir)
 
-        // Builds the AST in parallel. Rules are always executed in parallel.
-        // Can lead to speedups in larger projects. `false` by default.
-        parallel = true
+    detekt.include("**/*.kt")
+    detekt.include("**/*.kts")
+    detekt.exclude("**/resources/")
+    detekt.exclude("**/build/")
+    detekt.exclude("Writerside/codeSnippets/")
 
-        // Define the detekt configuration(s) you want to use.
-        // Defaults to the default detekt configuration.
-        config.setFrom("config/detekt/detekt.yml")
+    // Builds the AST in parallel. Rules are always executed in parallel.
+    // Can lead to speedups in larger projects. `false` by default.
+    detekt.parallel = true
 
-        // Applies the config files on top of detekt's default config file. `false` by default.
-        buildUponDefaultConfig = false
+    // Define the detekt configuration(s) you want to use.
+    // Defaults to the default detekt configuration.
+    detekt.config.setFrom("config/detekt/detekt.yml")
 
-        // Turns on all the rules. `false` by default.
-        allRules = false
+    // Applies the config files on top of detekt's default config file. `false` by default.
+    detekt.buildUponDefaultConfig = false
 
-        // Specifying a baseline file. All findings stored in this file in subsequent runs of detekt.
+    // Turns on all the rules. `false` by default.
+    detekt.allRules = false
+
+    // Specifying a baseline file. All findings stored in this file in subsequent runs of detekt.
 //    baseline = file("path/to/baseline.xml")
 
-        // Disables all default detekt rulesets and will only run detekt with custom rules
-        // defined in plugins passed in with `detektPlugins` configuration. `false` by default.
-        disableDefaultRuleSets = false
+    // Disables all default detekt rulesets and will only run detekt with custom rules
+    // defined in plugins passed in with `detektPlugins` configuration. `false` by default.
+    detekt.disableDefaultRuleSets = false
 
-        // Adds debug output during task execution. `false` by default.
-        debug = false
+    // Adds debug output during task execution. `false` by default.
+    detekt.debug = false
 
-        // If set to `true` the build does not fail when the
-        // maxIssues count was reached. Defaults to `false`.
-        ignoreFailures = true
+    // If set to `true` the build does not fail when the
+    // maxIssues count was reached. Defaults to `false`.
+    detekt.ignoreFailures = true
 
-        // Specify the base path for file paths in the formatted reports.
-        // If not set, all file paths reported will be absolute file path.
-        basePath = rootProject.projectDir.absolutePath
-    }
+    // Specify the base path for file paths in the formatted reports.
+    // If not set, all file paths reported will be absolute file path.
+    detekt.basePath = project.rootProject.projectDir.absolutePath
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 composeWheelPicker = "1.0.0-beta05"
 leakcanaryAndroid = "2.14"
-modo = "0.10.0"
+modo = "0.10.1"
 androidGradlePlugin = "8.4.0"
 detektComposeVersion = "0.3.20"
 detektVersion = "1.23.6"

--- a/modo-compose/src/main/java/com/github/terrakok/modo/ComposeRender.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/ComposeRender.kt
@@ -50,7 +50,7 @@ private val LocalAfterScreenContentOnDispose = staticCompositionLocalOf<() -> Un
  * 3. Handles lifecycle of [Screen] by adding [DisposableEffect] before and after content, in order to notify [ComposeRenderer]
  *    when [Screen.Content] is about to leave composition and when it has left composition.
  * @param modifier is a modifier that will be passed into [Screen.Content]
- * @param manualResumePause define whenever we are going to manually call [LifecycleDependency.onResume] and [LifecycleDependency.onPause]
+ * @param manualResumePause define whenever we are going to manually call [LifecycleDependency.showTransitionFinished] and [LifecycleDependency.hideTransitionStarted]
  * to emmit [ON_RESUME] and [ON_PAUSE]. Otherwise, [ON_RESUME] will be called straight after [ON_START] and [ON_PAUSE] will be called straight
  * before [ON_STOP].
  *

--- a/modo-compose/src/main/java/com/github/terrakok/modo/android/ModoScreenAndroidAdapter.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/android/ModoScreenAndroidAdapter.kt
@@ -50,15 +50,15 @@ import com.github.terrakok.modo.util.getApplication
 import java.util.concurrent.atomic.AtomicReference
 
 /**
- * Adapter for Screem, to support android-related features using Modo, such as:
- * 1. ViewModel support
- * 2. Lifecycle support
- * 3. SavedState support
+ * Adapter for Screen that provides android-related features support using Modo, such as:
+ * 1. ViewModel
+ * 2. Lifecycle
+ * 3. SavedState
  *
  * It the single instance of [ModoScreenAndroidAdapter] per Screen.
  */
 class ModoScreenAndroidAdapter private constructor(
-//    just for debug purpose.
+    // For debugging purposes
     internal val screen: Screen
 ) :
     LifecycleOwner,
@@ -101,10 +101,11 @@ class ModoScreenAndroidAdapter private constructor(
     private val application: Application? get() = atomicContext.get()?.applicationContext?.getApplication()
 
     /**
-     * Indicates that lifecycle should be moved to RESUMED state as soon as parent will be RESUMED.
+     * Holding transition state of the screen to be able to handle lifecycle events from parent properly.
+     * Check out [needPropagateLifecycleEventFromParent] for more details.
      */
     @Volatile
-    private var isResumePostponed: Boolean = false
+    private var screenTransitionState: ScreenTransitionState = ScreenTransitionState.HIDDEN
 
     init {
         controller.performAttach()
@@ -136,18 +137,18 @@ class ModoScreenAndroidAdapter private constructor(
         safeHandleLifecycleEvent(ON_DESTROY)
     }
 
-    override fun onPause() {
+    override fun hideTransitionStarted() {
+        screenTransitionState = ScreenTransitionState.HIDING
         safeHandleLifecycleEvent(ON_PAUSE)
     }
 
-    override fun onResume() {
+    override fun showTransitionFinished() {
+        screenTransitionState = ScreenTransitionState.SHOWN
         val parentState = atomicParentLifecycleOwner.get()?.lifecycle?.currentState
-        if (parentState == null || parentState != Lifecycle.State.RESUMED) {
-            // We need to do so, because child is ready to move to resumed state, when parent is not.
-            // It can happen when we display this screen as a first screen inside container, that is animating.
-            // So we need to wait until parent will be resumed and execute ON_RESUME event after it.
-            isResumePostponed = true
-        } else {
+        // It's crucial to check parent state, because our state can't be greater than a parent state.
+        // If this condition is not met, resuming will be done when parent will be resumed and screenTransitionState == ScreenTransitionState.SHOWN.
+        // It can happen when we display this screen as a first screen inside container, that is animating.
+        if (parentState != null && parentState == Lifecycle.State.RESUMED) {
             safeHandleLifecycleEvent(ON_RESUME)
         }
     }
@@ -253,15 +254,11 @@ class ModoScreenAndroidAdapter private constructor(
                     if (
                         needPropagateLifecycleEventFromParent(
                             event,
-                            isResumePostponed = isResumePostponed,
+                            screenTransitionState = screenTransitionState,
                             isActivityFinishing = activity?.isFinishing,
                             isChangingConfigurations = activity?.isChangingConfigurations
                         )
                     ) {
-                        // reset postpone resume flag because we moved state to resumed
-                        if (event == ON_RESUME) {
-                            isResumePostponed = false
-                        }
                         safeHandleLifecycleEvent(event)
                     }
                 }
@@ -285,8 +282,29 @@ class ModoScreenAndroidAdapter private constructor(
         val skippEvent = needSkipEvent(lifecycle.currentState, event)
         if (!skippEvent) {
 //            Log.d("ModoScreenAndroidAdapter", "${screen.screenKey} handleLifecycleEvent $event")
+            screenTransitionState = when {
+                // Whenever we receive ON_RESUME event, we need to move screen to SHOWN state to indicate that there is no transition of this screen.
+                event == Lifecycle.Event.ON_RESUME -> ScreenTransitionState.SHOWN
+                // Whe need to check transition state to distinguish between
+                // 1. finishing screen hiding transition. In this case, we need to move screen to hidden state.
+                // 2. hiding screen, because of lifecycle event. In this case we don't need to change animation state.
+                event == Lifecycle.Event.ON_STOP && screenTransitionState == ScreenTransitionState.HIDING -> ScreenTransitionState.HIDDEN
+                // Pause by itself doesn't mean that screen is hidden, it can be visible, but not active. F.e. when system dialog is shown.
+                else -> screenTransitionState
+            }
             lifecycle.handleLifecycleEvent(event)
         }
+    }
+
+    /**
+     * Enum that represents
+     */
+    private enum class ScreenTransitionState {
+        HIDING,
+        HIDDEN,
+        SHOWN
+        // There is no SHOWING state, because we cannot distinguish it by using lifecycle events and
+        // [hideTransitionStarted] and [showTransitionFinished] methods.
     }
 
     companion object {
@@ -315,9 +333,9 @@ class ModoScreenAndroidAdapter private constructor(
             ) { ModoScreenAndroidAdapter(screen) }
 
         @JvmStatic
-        fun needPropagateLifecycleEventFromParent(
+        private fun needPropagateLifecycleEventFromParent(
             event: Lifecycle.Event,
-            isResumePostponed: Boolean,
+            screenTransitionState: ScreenTransitionState,
             isActivityFinishing: Boolean?,
             isChangingConfigurations: Boolean?
         ) =
@@ -336,12 +354,13 @@ class ModoScreenAndroidAdapter private constructor(
                 event == ON_DESTROY && (isActivityFinishing == false || isChangingConfigurations == true) -> {
                     false
                 }
-                isResumePostponed && event == ON_RESUME -> {
+                screenTransitionState == ScreenTransitionState.SHOWN && event == ON_RESUME -> {
                     true
                 }
                 else -> {
-                    // Parent can only move lifecycle state down. Because parent cant be already resumed, but child is not, because of running animation.
-                    event !in moveLifecycleStateUpEvents
+                    // Except previous condition, parent can only move lifecycle state down.
+                    // Because parent cant be already resumed, but child is not, because of running animation.
+                    event in moveLifecycleStateDownEvents
                 }
             }
 

--- a/modo-compose/src/main/java/com/github/terrakok/modo/android/ModoScreenAndroidAdapter.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/android/ModoScreenAndroidAdapter.kt
@@ -100,6 +100,12 @@ class ModoScreenAndroidAdapter private constructor(
     private val atomicParentLifecycleOwner = AtomicReference<LifecycleOwner>()
     private val application: Application? get() = atomicContext.get()?.applicationContext?.getApplication()
 
+    /**
+     * Indicates that lifecycle should be moved to RESUMED state as soon as parent will be RESUMED.
+     */
+    @Volatile
+    private var isResumePostponed: Boolean = false
+
     init {
         controller.performAttach()
         enableSavedStateHandles()
@@ -135,7 +141,15 @@ class ModoScreenAndroidAdapter private constructor(
     }
 
     override fun onResume() {
-        safeHandleLifecycleEvent(ON_RESUME)
+        val parentState = atomicParentLifecycleOwner.get()?.lifecycle?.currentState
+        if (parentState == null || parentState != Lifecycle.State.RESUMED) {
+            // We need to do so, because child is ready to move to resumed state, when parent is not.
+            // It can happen when we display this screen as a first screen inside container, that is animating.
+            // So we need to wait until parent will be resumed and execute ON_RESUME event after it.
+            isResumePostponed = true
+        } else {
+            safeHandleLifecycleEvent(ON_RESUME)
+        }
     }
 
     override fun toString(): String = "${ModoScreenAndroidAdapter::class.simpleName}, screenKey: ${screen.screenKey}"
@@ -239,10 +253,15 @@ class ModoScreenAndroidAdapter private constructor(
                     if (
                         needPropagateLifecycleEventFromParent(
                             event,
+                            isResumePostponed = isResumePostponed,
                             isActivityFinishing = activity?.isFinishing,
                             isChangingConfigurations = activity?.isChangingConfigurations
                         )
                     ) {
+                        // reset postpone resume flag because we moved state to resumed
+                        if (event == ON_RESUME) {
+                            isResumePostponed = false
+                        }
                         safeHandleLifecycleEvent(event)
                     }
                 }
@@ -298,6 +317,7 @@ class ModoScreenAndroidAdapter private constructor(
         @JvmStatic
         fun needPropagateLifecycleEventFromParent(
             event: Lifecycle.Event,
+            isResumePostponed: Boolean,
             isActivityFinishing: Boolean?,
             isChangingConfigurations: Boolean?
         ) =
@@ -312,11 +332,17 @@ class ModoScreenAndroidAdapter private constructor(
              *
              * In the case of Fragments, we unsubscribe before ON_DESTROY event, so there is no problem with this.
              */
-            if (event == ON_DESTROY && (isActivityFinishing == false || isChangingConfigurations == true)) {
-                false
-            } else {
-                // Parent can only move lifecycle state down. Because parent cant be already resumed, but child is not, because of running animation.
-                event !in moveLifecycleStateUpEvents
+            when {
+                event == ON_DESTROY && (isActivityFinishing == false || isChangingConfigurations == true) -> {
+                    false
+                }
+                isResumePostponed && event == ON_RESUME -> {
+                    true
+                }
+                else -> {
+                    // Parent can only move lifecycle state down. Because parent cant be already resumed, but child is not, because of running animation.
+                    event !in moveLifecycleStateUpEvents
+                }
             }
 
         @JvmStatic

--- a/modo-compose/src/main/java/com/github/terrakok/modo/animation/ScreenTransitions.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/animation/ScreenTransitions.kt
@@ -56,6 +56,7 @@ fun ComposeRendererScope<*>.ScreenTransition(
         modifier = modifier,
         contentKey = { it.screenKey },
     ) { screen ->
+        content(screen)
         DisposableEffect(transition.currentState, transition.targetState) {
 //            Log.d(
 //                "LifecycleDebug",
@@ -66,15 +67,14 @@ fun ComposeRendererScope<*>.ScreenTransition(
             if (screen == transition.currentState && screen != transition.targetState) {
                 // Start of animation that hides this screen, so we should pause lifecycle
 //                Log.d("LifecycleDebug", "${screen.screenKey}: ON_PAUSE!")
-                screen.lifecycleDependency()?.onPause()
+                screen.lifecycleDependency()?.hideTransitionStarted()
             }
             if (transition.currentState == transition.targetState && screen == transition.currentState) {
                 // Finish of animation that shows this screen, so we should resume lifecycle
 //                Log.d("LifecycleDebug", "${screen.screenKey}: ON_RESUME!")
-                screen.lifecycleDependency()?.onResume()
+                screen.lifecycleDependency()?.showTransitionFinished()
             }
             onDispose { }
         }
-        content(screen)
     }
 }

--- a/modo-compose/src/main/java/com/github/terrakok/modo/lifecycle/LifecycleDependency.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/lifecycle/LifecycleDependency.kt
@@ -12,13 +12,13 @@ interface LifecycleDependency {
      * Should be called when associated screen is ready to be moved to ON_RESUME state.
      * F.e. when screen appearance animation is finished and screen is fully visible.
      */
-    fun onResume()
+    fun showTransitionFinished()
 
     /**
      * Should be called when associated screen is ready to be moved to ON_PAUSE state.
      * F.e. when screen hide animation is started and screen is not fully visible.
      */
-    fun onPause()
+    fun hideTransitionStarted()
 
     fun onPreDispose()
 

--- a/modo-compose/src/main/java/com/github/terrakok/modo/stack/StackScreen.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/stack/StackScreen.kt
@@ -174,7 +174,7 @@ abstract class StackScreen(
                 }
             }
             DialogScreen.DialogConfig.Custom -> {
-                DecorateCustomDialog(dialog, modifier) {
+                DecorateCustomDialog(dialog, modifier) { modifier ->
                     Content(dialog, modifier, content)
                 }
             }

--- a/modo-compose/src/main/java/com/github/terrakok/modo/stack/StackState.kt
+++ b/modo-compose/src/main/java/com/github/terrakok/modo/stack/StackState.kt
@@ -10,8 +10,9 @@ import kotlinx.parcelize.Parcelize
 
 typealias StackNavModel = NavModel<StackState, StackAction>
 
-fun StackNavModel(stack: List<Screen>) = StackNavModel(StackState(stack))
-fun StackNavModel(screen: Screen) = StackNavModel(listOf(screen))
+fun StackNavModel(stack: List<Screen>): StackNavModel = StackNavModel(StackState(stack))
+fun StackNavModel(screen: Screen): StackNavModel = StackNavModel(listOf(screen))
+fun StackNavModel(vararg screens: Screen): StackNavModel = StackNavModel(screens.toList())
 
 @Stable
 interface StackNavContainer : NavigationContainer<StackState, StackAction>

--- a/sample/src/main/java/com/github/terrakok/modo/sample/Animations.kt
+++ b/sample/src/main/java/com/github/terrakok/modo/sample/Animations.kt
@@ -9,6 +9,7 @@ import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.IntOffset
 import com.github.terrakok.modo.ComposeRendererScope
 import com.github.terrakok.modo.DialogScreen
 import com.github.terrakok.modo.ExperimentalModoApi
@@ -30,21 +31,23 @@ fun ComposeRendererScope<StackState>.SlideTransition(
             val transitionType = calculateStackTransitionType(oldState, newState)
             when {
                 transitionType == StackTransitionType.Replace -> {
-                    scaleIn(initialScale = 2f) + fadeIn() togetherWith fadeOut()
+                    val animationSpec = tween<Float>(durationMillis = SampleAppConfig.animationDurationMs)
+                    scaleIn(initialScale = 2f, animationSpec = animationSpec) + fadeIn(animationSpec) togetherWith
+                        fadeOut(animationSpec)
                 }
-                oldState?.stack?.last() is DialogScreen -> {
-                    fadeIn() togetherWith fadeOut()
-                }
-                oldState?.stack?.last() !is DialogScreen && newState?.stack?.last() is DialogScreen -> {
-                    fadeIn() togetherWith fadeOut()
+                oldState?.stack?.last() is DialogScreen ||
+                    oldState?.stack?.last() !is DialogScreen && newState?.stack?.last() is DialogScreen -> {
+                    val animationSpec = tween<Float>(durationMillis = SampleAppConfig.animationDurationMs)
+                    fadeIn(animationSpec) togetherWith fadeOut(animationSpec)
                 }
                 else -> {
                     val (initialOffset, targetOffset) = when (transitionType) {
                         StackTransitionType.Pop -> ({ size: Int -> -size }) to ({ size: Int -> size })
                         else -> ({ size: Int -> size }) to ({ size: Int -> -size })
                     }
-                    slideInHorizontally(initialOffsetX = initialOffset, animationSpec = tween(durationMillis = 1000)) togetherWith
-                        slideOutHorizontally(targetOffsetX = targetOffset, animationSpec = tween(durationMillis = 1000))
+                    val animationSpec = tween<IntOffset>(durationMillis = SampleAppConfig.animationDurationMs)
+                    slideInHorizontally(initialOffsetX = initialOffset, animationSpec = animationSpec) togetherWith
+                        slideOutHorizontally(targetOffsetX = targetOffset, animationSpec = animationSpec)
                 }
             }
         }

--- a/sample/src/main/java/com/github/terrakok/modo/sample/SampleAppConfig.kt
+++ b/sample/src/main/java/com/github/terrakok/modo/sample/SampleAppConfig.kt
@@ -2,4 +2,6 @@ package com.github.terrakok.modo.sample
 
 object SampleAppConfig {
     const val counterEnabled: Boolean = true
+    const val displayLifecycleEvents: Boolean = false
+    const val animationDurationMs = 1000
 }

--- a/sample/src/main/java/com/github/terrakok/modo/sample/screens/ButtonsList.kt
+++ b/sample/src/main/java/com/github/terrakok/modo/sample/screens/ButtonsList.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
-fun ButtonsState(buttons: List<ModoButtonSpec>) = GroupedButtonsState(
+fun ButtonsState(buttons: List<ModoButtonSpec>): GroupedButtonsState = GroupedButtonsState(
     listOf(GroupedButtonsState.Group(null, buttons))
 )
 

--- a/sample/src/main/java/com/github/terrakok/modo/sample/screens/MainScreen.kt
+++ b/sample/src/main/java/com/github/terrakok/modo/sample/screens/MainScreen.kt
@@ -32,6 +32,7 @@ import com.github.terrakok.modo.sample.screens.stack.StackActionsScreen
 import com.github.terrakok.modo.sample.screens.viewmodel.AndroidViewModelSampleScreen
 import com.github.terrakok.modo.stack.LocalStackNavigation
 import com.github.terrakok.modo.stack.StackNavContainer
+import com.github.terrakok.modo.stack.StackNavModel
 import com.github.terrakok.modo.stack.back
 import com.github.terrakok.modo.stack.forward
 import com.github.terrakok.modo.util.getActivity
@@ -164,6 +165,25 @@ private fun rememberButtons(
                     buttons = listOf(
                         ModoButtonSpec("Screen Lifecycle") { navigation?.forward(LifecycleSampleScreen(i + 1)) },
                         ModoButtonSpec("Keyboard + Lifecycle") { navigation?.forward(KeyboardWithLifecycleScreen()) },
+                        ModoButtonSpec("Open predefined flow") {
+                            navigation?.forward(
+                                CustomStackSample(
+                                    i + 1,
+                                    StackNavModel(
+                                        MainScreen(i + 2),
+                                        MainScreen(i + 3),
+                                        KeyboardWithLifecycleScreen(),
+                                        CustomStackSample(
+                                            i = i + 4,
+                                            navModel = StackNavModel(
+                                                MainScreen(i + 5),
+                                                KeyboardWithLifecycleScreen(),
+                                            ),
+                                        ),
+                                    )
+                                )
+                            )
+                        },
                     )
                 ),
                 GroupedButtonsState.Group(

--- a/sample/src/main/java/com/github/terrakok/modo/sample/screens/MainScreen.kt
+++ b/sample/src/main/java/com/github/terrakok/modo/sample/screens/MainScreen.kt
@@ -109,7 +109,7 @@ internal fun Screen.MainScreenContent(
     )
 }
 
-@Suppress("LongMethod")
+@Suppress("LongMethod", "MagicNumber")
 @Composable
 private fun rememberButtons(
     screenKey: ScreenKey,

--- a/sample/src/main/java/com/github/terrakok/modo/sample/screens/PauseButtonState.kt
+++ b/sample/src/main/java/com/github/terrakok/modo/sample/screens/PauseButtonState.kt
@@ -1,0 +1,14 @@
+package com.github.terrakok.modo.sample.screens
+
+import android.content.Context
+import android.content.Intent
+
+fun PauseButtonSpec(context: Context) = ModoButtonSpec("Pause") {
+    val shareIntent = Intent().apply {
+        action = Intent.ACTION_SEND
+        putExtra(Intent.EXTRA_TEXT, "This is a test message.")
+        type = "text/plain"
+    }
+    // Launch the share dialog
+    context.startActivity(Intent.createChooser(shareIntent, "Share via"))
+}

--- a/sample/src/main/java/com/github/terrakok/modo/sample/screens/base/ButtonsScreenContent.kt
+++ b/sample/src/main/java/com/github/terrakok/modo/sample/screens/base/ButtonsScreenContent.kt
@@ -1,5 +1,6 @@
 package com.github.terrakok.modo.sample.screens.base
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
@@ -28,7 +29,6 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.github.terrakok.modo.ExperimentalModoApi
 import com.github.terrakok.modo.Screen
 import com.github.terrakok.modo.ScreenKey
-import com.github.terrakok.modo.lifecycle.LifecycleScreenEffect
 import com.github.terrakok.modo.sample.SampleAppConfig
 import com.github.terrakok.modo.sample.randomBackground
 import com.github.terrakok.modo.sample.screens.ButtonsState
@@ -120,11 +120,11 @@ fun Screen.LogLifecycle() {
             lifecycleOwner.lifecycle.removeObserver(observer)
         }
     }
-    LifecycleScreenEffect {
-        LifecycleEventObserver { source, event ->
-            logcat(tag = "LifecycleDebug") { "$screenKey LifecycleScreenEffect $event" }
-        }
-    }
+//    LifecycleScreenEffect {
+//        LifecycleEventObserver { source, event ->
+//            logcat(tag = "LifecycleDebug") { "$screenKey LifecycleScreenEffect $event" }
+//        }
+//    }
 }
 
 @Composable
@@ -136,29 +136,32 @@ internal fun SampleScreenContent(
     modifier: Modifier = Modifier,
     content: @Composable ColumnScope.() -> Unit
 ) {
-    Column(
+    Box(
         modifier = modifier
             .randomBackground()
             .windowInsetsPadding(WindowInsets.systemBars)
             .padding(8.dp),
     ) {
-        Text(
-            text = counter.toString()
-        )
-        Text(
-            text = "$screenName $screenIndex",
-            style = MaterialTheme.typography.h5,
-            modifier = Modifier.fillMaxWidth(),
-            textAlign = TextAlign.Center
-        )
-        Text(
-            text = "ScreenKey: ${screenKey.value}",
-            style = MaterialTheme.typography.body1,
-            modifier = Modifier.fillMaxWidth(),
-            textAlign = TextAlign.Center
-        )
-        Spacer(modifier = Modifier.size(16.dp))
-        content()
+        Column {
+            Text(
+                text = counter.toString()
+            )
+            Text(
+                text = "$screenName $screenIndex",
+                style = MaterialTheme.typography.h5,
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center
+            )
+            Text(
+                text = "ScreenKey: ${screenKey.value}",
+                style = MaterialTheme.typography.body1,
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = Modifier.size(16.dp))
+            content()
+        }
+        LifecycleEventsHistory()
     }
 }
 

--- a/sample/src/main/java/com/github/terrakok/modo/sample/screens/base/ContextUtils.kt
+++ b/sample/src/main/java/com/github/terrakok/modo/sample/screens/base/ContextUtils.kt
@@ -1,0 +1,17 @@
+package com.github.terrakok.modo.sample.screens.base
+
+import android.content.Context
+import android.content.Intent
+
+fun Context.openShareText(
+    text: String = "This is a test message.",
+    title: String = "Share via"
+) {
+    val shareIntent = Intent().apply {
+        action = Intent.ACTION_SEND
+        putExtra(Intent.EXTRA_TEXT, text)
+        type = "text/plain"
+    }
+    // Launch the share dialog
+    startActivity(Intent.createChooser(shareIntent, title))
+}

--- a/sample/src/main/java/com/github/terrakok/modo/sample/screens/base/LifecycleEventsHistory.kt
+++ b/sample/src/main/java/com/github/terrakok/modo/sample/screens/base/LifecycleEventsHistory.kt
@@ -1,0 +1,126 @@
+package com.github.terrakok.modo.sample.screens.base
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Divider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.runtime.toMutableStateList
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.github.terrakok.modo.sample.SampleAppConfig
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+
+@Composable
+fun LifecycleEventsHistory(
+    modifier: Modifier = Modifier,
+    key: String? = null,
+    enabled: Boolean = SampleAppConfig.displayLifecycleEvents,
+    lifecycleEventsHistory: SnapshotStateList<Lifecycle.Event> =
+        viewModel(key = key) {
+            LifecycleEventsViewModel(createSavedStateHandle())
+        }.lifecycleEventsHistory,
+    fontSize: TextUnit = 16.sp,
+) {
+    if (enabled) {
+        val lifecycleOwner = LocalLifecycleOwner.current
+        val context = LocalContext.current
+
+        DisposableEffect(Unit) {
+            val observer = LifecycleEventObserver { _, event ->
+                lifecycleEventsHistory += event
+            }
+            lifecycleOwner.lifecycle.addObserver(observer)
+            onDispose {
+                lifecycleOwner.lifecycle.removeObserver(observer)
+            }
+        }
+
+        Column(
+            modifier = modifier
+                .width(IntrinsicSize.Max)
+                .pointerInput(Unit) {
+                    detectTapGestures(
+                        onLongPress = {
+                            lifecycleEventsHistory.clear()
+                        },
+                        onDoubleTap = {
+                            context.openShareText()
+                        }
+                    )
+                }
+        ) {
+            for (item in lifecycleEventsHistory) {
+                Text(text = item.name, fontSize = fontSize)
+                if (item == Lifecycle.Event.ON_STOP) {
+                    Divider(
+                        color = Color.Red,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun BoxScope.LifecycleEventsHistory(
+    modifier: Modifier = Modifier,
+    alignment: Alignment = Alignment.TopEnd,
+) = LifecycleEventsHistory(
+    fontSize = 8.sp,
+    modifier = modifier
+        .background(Color.White.copy(alpha = 0.5f))
+        .align(alignment)
+)
+
+class LifecycleEventsViewModel(
+    private val savedStateHandle: SavedStateHandle
+) : ViewModel() {
+    companion object {
+        private const val EVENTS_KEY = "events"
+    }
+
+    // Initialize the SnapshotStateList from saved state if available, or with default values
+    val lifecycleEventsHistory: SnapshotStateList<Lifecycle.Event> = savedStateHandle
+        .get<List<Int>>(EVENTS_KEY)
+        ?.map { ordinal -> Lifecycle.Event.entries[ordinal] }
+        ?.toMutableStateList()
+        ?: mutableStateListOf()
+
+    init {
+        // Observe changes in the eventList and update the SavedStateHandle when it changes
+        snapshotFlow {
+            derivedStateOf { lifecycleEventsHistory.toList() }.value
+        }
+            .onEach {
+                savedStateHandle[EVENTS_KEY] = it.map { it.ordinal }
+            }
+            .launchIn(viewModelScope)
+    }
+
+}

--- a/sample/src/main/java/com/github/terrakok/modo/sample/screens/containers/CustomStackSample.kt
+++ b/sample/src/main/java/com/github/terrakok/modo/sample/screens/containers/CustomStackSample.kt
@@ -48,18 +48,20 @@ class CustomStackSample(
             logcat { "Screen $screenKey was removed" }
         }
         val navigation = LocalStackNavigation.current
-        Box {
+        Box(modifier) {
             SampleScreenContent(
                 screenIndex = i,
                 screenName = "SampleContainerScreen",
                 screenKey = screenKey
             ) {
-                TopScreenContent(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .clip(RoundedCornerShape(16.dp))
-                ) { modifier ->
-                    SlideTransition(modifier)
+                Box {
+                    TopScreenContent(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .clip(RoundedCornerShape(16.dp)),
+                    ) { modifier ->
+                        SlideTransition(modifier)
+                    }
                 }
             }
             CancelButton(

--- a/sample/src/main/java/com/github/terrakok/modo/sample/screens/containers/SampleStack.kt
+++ b/sample/src/main/java/com/github/terrakok/modo/sample/screens/containers/SampleStack.kt
@@ -12,12 +12,15 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.sp
 import com.github.terrakok.modo.DialogScreen
 import com.github.terrakok.modo.ExperimentalModoApi
 import com.github.terrakok.modo.Screen
 import com.github.terrakok.modo.sample.SlideTransition
+import com.github.terrakok.modo.sample.screens.base.LifecycleEventsHistory
 import com.github.terrakok.modo.sample.screens.base.LogLifecycle
 import com.github.terrakok.modo.sample.screens.dialogs.SampleBottomSheet
 import com.github.terrakok.modo.sample.screens.dialogs.SampleBottomSheetStack
@@ -52,16 +55,24 @@ open class SampleStack(
 
     constructor(rootScreen: Screen) : this(StackNavModel(rootScreen))
 
-    @OptIn(ExperimentalModoApi::class)
     @Composable
     override fun Content(modifier: Modifier) {
         LogLifecycle()
-        TopScreenContent(
-            modifier,
-            dialogModifier = modifier.fillMaxSize()
-        ) { modifier ->
-            SlideTransition(modifier)
+        Box(modifier.fillMaxSize()) {
+            TopScreenContent(
+                modifier = Modifier.fillMaxSize(),
+                dialogModifier = Modifier.fillMaxSize()
+            ) { contentModifier ->
+                SlideTransition(contentModifier)
+            }
+            LifecycleEventsHistory(
+                fontSize = 8.sp,
+                modifier = Modifier
+                    .background(Color.White.copy(alpha = 0.5f))
+                    .align(Alignment.TopEnd)
+            )
         }
+
     }
 
     @OptIn(ExperimentalModoApi::class)

--- a/sample/src/main/java/com/github/terrakok/modo/sample/screens/dialogs/DialogsPlayground.kt
+++ b/sample/src/main/java/com/github/terrakok/modo/sample/screens/dialogs/DialogsPlayground.kt
@@ -25,7 +25,7 @@ class DialogsPlayground(
 ) : Screen {
     @Composable
     override fun Content(modifier: Modifier) {
-        DialogsPlaygroundContent(screenIndex)
+        DialogsPlaygroundContent(screenIndex, modifier)
     }
 }
 

--- a/sample/src/main/java/com/github/terrakok/modo/sample/screens/dialogs/SampleDialog.kt
+++ b/sample/src/main/java/com/github/terrakok/modo/sample/screens/dialogs/SampleDialog.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -57,7 +58,7 @@ class SampleDialog(
         DialogScreen.DialogConfig.Custom
     }
 
-    @Suppress("ModifierNotUsedAtRoot")
+    @Suppress("MagicNumber", "ModifierNotUsedAtRoot")
     @Composable
     override fun Content(modifier: Modifier) {
         SetupSystemBar()
@@ -68,15 +69,16 @@ class SampleDialog(
         }
         val navigation = LocalStackNavigation.current
         if (systemDialog) {
-            Box(
-                modifier
+            Box(modifier) {
+                val contentModifier = Modifier
                     .clip(RoundedCornerShape(16.dp))
+                    .fillMaxHeight(0.6f)
                     .background(Color.White)
-            ) {
+                    .align(Alignment.Center)
                 if (dialogsPlayground) {
-                    DialogsPlaygroundContent(screenIndex)
+                    DialogsPlaygroundContent(screenIndex, contentModifier)
                 } else {
-                    MainScreenContent(screenIndex, screenKey, navigation)
+                    MainScreenContent(screenIndex, screenKey, navigation, contentModifier)
                 }
             }
         } else {
@@ -86,9 +88,11 @@ class SampleDialog(
                     screenName = "SampleDialog",
                     state = rememberDialogsButtons(LocalContainerScreen.current as StackScreen, screenIndex),
                     modifier = modifier
-                        .align(Alignment.Center)
+                        .fillMaxHeight(0.6f)
                         .padding(horizontal = 50.dp)
                         .clip(RoundedCornerShape(16.dp))
+                        .background(Color.White)
+                        .align(Alignment.Center)
                         // TODO: deal with A11Y and remove it from A11Y tree
                         .clickable(
                             enabled = false,

--- a/sample/src/main/java/com/github/terrakok/modo/sample/screens/dialogs/SampleDialogWithStack.kt
+++ b/sample/src/main/java/com/github/terrakok/modo/sample/screens/dialogs/SampleDialogWithStack.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -59,40 +58,40 @@ class SampleDialogWithStack(
                 logcat(tag = "SampleDialog") { "$screenKey $event" }
             }
         }
-        if (systemDialog) {
-            Box(
-                modifier
-                    .fillMaxHeight(0.6f)
-                    .clip(RoundedCornerShape(16.dp))
-                    .background(Color.White)
-            ) {
-                TopScreenContent { screenModifier ->
-                    SlideTransition(
-                        Modifier,
-                        screenModifier = screenModifier
-                            .fillMaxSize()
-                            .background(Color.Black)
-                    )
+        Box(modifier) {
+            if (systemDialog) {
+                TopScreenContent(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(16.dp))
+                        .fillMaxHeight(0.6f)
+                        .background(Color.White)
+                        .align(Alignment.Center),
+                    dialogModifier = Modifier
+                        .clip(RoundedCornerShape(16.dp))
+                        .fillMaxHeight(0.6f)
+                        .align(Alignment.Center)
+                ) { contentModifier ->
+                    SlideTransition(contentModifier)
                 }
-            }
-        } else {
-            Box(modifier = modifier.fillMaxSize()) {
-                TopScreenContent { transitionModifier ->
+            } else {
+                TopScreenContent(
+                    modifier = Modifier
+                        .fillMaxHeight(0.6f)
+                        .padding(horizontal = 50.dp)
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(Color.White)
+                        .align(Alignment.Center)
+                        // TODO: deal with A11Y and remove it from A11Y tree
+                        .clickable(
+                            enabled = false,
+                            interactionSource = remember {
+                                MutableInteractionSource()
+                            },
+                            indication = null
+                        ) {}
+                ) { transitionModifier ->
                     SlideTransition(
-                        modifier = transitionModifier
-                            .align(Alignment.Center)
-                            .padding(horizontal = 50.dp)
-                            .clip(RoundedCornerShape(16.dp)),
-                        screenModifier = Modifier
-                            .background(Color.White)
-                            // TODO: deal with A11Y and remove it from A11Y tree
-                            .clickable(
-                                enabled = false,
-                                interactionSource = remember {
-                                    MutableInteractionSource()
-                                },
-                                indication = null
-                            ) {}
+                        modifier = transitionModifier,
                     )
                 }
             }

--- a/sample/src/main/java/com/github/terrakok/modo/sample/screens/lifecycle/KeyboardWithLifecycleScreen.kt
+++ b/sample/src/main/java/com/github/terrakok/modo/sample/screens/lifecycle/KeyboardWithLifecycleScreen.kt
@@ -24,6 +24,7 @@ import com.github.terrakok.modo.ScreenKey
 import com.github.terrakok.modo.generateScreenKey
 import com.github.terrakok.modo.sample.screens.ModoButton
 import com.github.terrakok.modo.sample.screens.ModoButtonSpec
+import com.github.terrakok.modo.sample.screens.base.LogLifecycle
 import com.github.terrakok.modo.stack.LocalStackNavigation
 import com.github.terrakok.modo.stack.back
 import com.github.terrakok.modo.util.getActivity
@@ -39,6 +40,7 @@ class KeyboardWithLifecycleScreen(
 ) : Screen {
     @Composable
     override fun Content(modifier: Modifier) {
+        LogLifecycle()
         Column(modifier.windowInsetsPadding(WindowInsets.systemBars)) {
             val stackNavigation = LocalStackNavigation.current
             ModoButton(ModoButtonSpec("Back") { stackNavigation.back() })

--- a/sample/src/main/java/com/github/terrakok/modo/sample/screens/lifecycle/KeyboardWithLifecycleScreen.kt
+++ b/sample/src/main/java/com/github/terrakok/modo/sample/screens/lifecycle/KeyboardWithLifecycleScreen.kt
@@ -33,7 +33,6 @@ import com.github.terrakok.modo.sample.screens.base.LifecycleEventsHistory
 import com.github.terrakok.modo.sample.screens.base.LogLifecycle
 import com.github.terrakok.modo.stack.LocalStackNavigation
 import com.github.terrakok.modo.stack.back
-import com.github.terrakok.modo.util.getActivity
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -70,10 +69,8 @@ class KeyboardWithLifecycleScreen(
                             focusRequester.requestFocus()
                         }
                         Lifecycle.Event.ON_PAUSE -> {
-                            if (context.getActivity()?.isChangingConfigurations != true) {
-                                focusRequester.freeFocus()
-                                keyboardController?.hide()
-                            }
+                            focusRequester.freeFocus()
+                            keyboardController?.hide()
                         }
                         else -> {}
                     }

--- a/sample/src/main/java/com/github/terrakok/modo/sample/screens/lifecycle/KeyboardWithLifecycleScreen.kt
+++ b/sample/src/main/java/com/github/terrakok/modo/sample/screens/lifecycle/KeyboardWithLifecycleScreen.kt
@@ -1,8 +1,11 @@
 package com.github.terrakok.modo.sample.screens.lifecycle
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -16,6 +19,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -24,6 +28,8 @@ import com.github.terrakok.modo.ScreenKey
 import com.github.terrakok.modo.generateScreenKey
 import com.github.terrakok.modo.sample.screens.ModoButton
 import com.github.terrakok.modo.sample.screens.ModoButtonSpec
+import com.github.terrakok.modo.sample.screens.PauseButtonSpec
+import com.github.terrakok.modo.sample.screens.base.LifecycleEventsHistory
 import com.github.terrakok.modo.sample.screens.base.LogLifecycle
 import com.github.terrakok.modo.stack.LocalStackNavigation
 import com.github.terrakok.modo.stack.back
@@ -43,7 +49,13 @@ class KeyboardWithLifecycleScreen(
         LogLifecycle()
         Column(modifier.windowInsetsPadding(WindowInsets.systemBars)) {
             val stackNavigation = LocalStackNavigation.current
-            ModoButton(ModoButtonSpec("Back") { stackNavigation.back() })
+            val context = LocalContext.current
+
+            Row {
+                ModoButton(ModoButtonSpec("Back") { stackNavigation.back() })
+                Spacer(Modifier.width(8.dp))
+                ModoButton(PauseButtonSpec(context))
+            }
 
             Text("Show ON_RESUME, hide ON_PAUSE")
 
@@ -51,7 +63,6 @@ class KeyboardWithLifecycleScreen(
             val focusRequester = remember { FocusRequester() }
             val lifecycleOwner = LocalLifecycleOwner.current
             val keyboardController = LocalSoftwareKeyboardController.current
-            val context = LocalContext.current
             DisposableEffect(this) {
                 val observer = LifecycleEventObserver { _, event ->
                     when (event) {
@@ -73,6 +84,7 @@ class KeyboardWithLifecycleScreen(
                 }
             }
             TextField(text, setText, modifier = Modifier.focusRequester(focusRequester))
+            LifecycleEventsHistory()
         }
     }
 }

--- a/sample/src/main/java/com/github/terrakok/modo/sample/screens/lifecycle/LifecycleSampleScreen.kt
+++ b/sample/src/main/java/com/github/terrakok/modo/sample/screens/lifecycle/LifecycleSampleScreen.kt
@@ -1,19 +1,13 @@
 package com.github.terrakok.modo.sample.screens.lifecycle
 
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.material.Text
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
-import androidx.lifecycle.Lifecycle
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.eventFlow
@@ -22,11 +16,12 @@ import com.github.terrakok.modo.Screen
 import com.github.terrakok.modo.ScreenKey
 import com.github.terrakok.modo.generateScreenKey
 import com.github.terrakok.modo.lifecycle.LaunchedScreenEffect
-import com.github.terrakok.modo.lifecycle.LifecycleScreenEffect
 import com.github.terrakok.modo.sample.screens.ButtonsState
 import com.github.terrakok.modo.sample.screens.GroupedButtonsList
 import com.github.terrakok.modo.sample.screens.MainScreen
 import com.github.terrakok.modo.sample.screens.ModoButtonSpec
+import com.github.terrakok.modo.sample.screens.PauseButtonSpec
+import com.github.terrakok.modo.sample.screens.base.LifecycleEventsHistory
 import com.github.terrakok.modo.sample.screens.base.SampleScreenContent
 import com.github.terrakok.modo.sample.screens.base.rememberCounterState
 import com.github.terrakok.modo.stack.LocalStackNavigation
@@ -51,11 +46,21 @@ class LifecycleSampleScreen(
     @OptIn(ExperimentalModoApi::class, ExperimentalStdlibApi::class)
     @Composable
     override fun Content(modifier: Modifier) {
-        var lifecycleEventsHistory by rememberSaveable {
-            mutableStateOf(listOf<Lifecycle.Event>())
-        }
-        val scaffoldState = rememberScaffoldState()
         val counter by rememberCounterState()
+        val lifecycleOwner = LocalLifecycleOwner.current
+
+        DisposableEffect(this) {
+            val observer = LifecycleEventObserver { _, event ->
+                logcat(TAG) { "DisposableEffect: event $event. Counter: $counter." }
+            }
+            lifecycleOwner.lifecycle.addObserver(observer)
+            onDispose {
+                logcat(TAG) { "DisposableEffect: on dispose" }
+                lifecycleOwner.lifecycle.removeObserver(observer)
+            }
+        }
+
+        val scaffoldState = rememberScaffoldState()
 
         // This effect is going to be launched once per screen an triggered even if screen left composition!
         // So be careful with passing any data to lambda which lifecycle is shorter than screen lifecycle.
@@ -64,7 +69,6 @@ class LifecycleSampleScreen(
             // Doing so will cause a leak of the scaffoldState.
             scaffoldState.snackbarHostState.showSnackbar("LaunchedScreenEffect! Counter: $counter.")
         }
-        val lifecycleOwner = LocalLifecycleOwner.current
         LaunchedEffect(Unit) {
             // Use Dispatchers.Main.immediate, otherwise you will lose ON_PAUSE, ON_STOP, ON_DESTROY events,
             // because of peculiarities of coroutines - it removes lifecycle observer before handling effects
@@ -77,23 +81,8 @@ class LifecycleSampleScreen(
                 }
             }
         }
-        DisposableEffect(this) {
-            val observer = LifecycleEventObserver { _, event ->
-                logcat(TAG) { "DisposableEffect: event $event. Counter: $counter." }
-            }
-            lifecycleOwner.lifecycle.addObserver(observer)
-            onDispose {
-                logcat(TAG) { "DisposableEffect: on dispose" }
-                lifecycleOwner.lifecycle.removeObserver(observer)
-            }
-        }
-        LifecycleScreenEffect {
-            LifecycleEventObserver { _, event ->
-                lifecycleEventsHistory += event
-                logcat(TAG) { "LifecycleScreenEffect: event $event. Counter: $counter." }
-            }
-        }
         val navigation = LocalStackNavigation.current
+        val context = LocalContext.current
         SampleScreenContent(
             screenIndex = screenIndex,
             screenName = "ScreenEffectsSampleScreen",
@@ -102,20 +91,18 @@ class LifecycleSampleScreen(
             modifier = modifier,
         ) {
             GroupedButtonsList(
-                state = remember {
+                state = rememberUpdatedState(
                     listOf(
+                        ModoButtonSpec("Back") { navigation.back() },
                         ModoButtonSpec("Forward") { navigation.forward(MainScreen(screenIndex + 1)) },
-                        ModoButtonSpec("Back") { navigation.back() }
+                        PauseButtonSpec(context),
                     ).let {
                         ButtonsState(it)
                     }
-                }
+                ).value
             )
-            LazyColumn {
-                items(lifecycleEventsHistory) {
-                    Text(text = it.name)
-                }
-            }
+
+            LifecycleEventsHistory(key = screenKey.value, enabled = true)
         }
     }
 }

--- a/workshop-app/src/main/kotlin/io/github/ikarenkov/workshop/screens/profile_setup/ProfileSetupFlowViewModel.kt
+++ b/workshop-app/src/main/kotlin/io/github/ikarenkov/workshop/screens/profile_setup/ProfileSetupFlowViewModel.kt
@@ -1,12 +1,9 @@
 package io.github.ikarenkov.workshop.screens.profile_setup
 
 import androidx.lifecycle.ViewModel
-import com.github.terrakok.modo.Screen
 import com.github.terrakok.modo.stack.StackState
 import io.github.ikarenkov.workshop.data.ClimberProfileRepository
 import io.github.ikarenkov.workshop.domain.ClimberProfile
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 
 // TODO: Workshop 5.1 - use VM
 class ProfileSetupFlowViewModel(


### PR DESCRIPTION
Fixed logic of propagation resume event to child. 
* Now you can safely display system dialog and go back, screens will be moved to resume state, when before they stated in started state
* When child is ready to be resumed, but parent is only in started state, child will be resumed as soon as parent moved to resumed state
* Introduced documentation about Lifecycle