### PR TITLE
Add GitHub Release workflow and bump to 0.12.0

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,146 @@
+name: GitHub Release
+run-name: GH Release from ${{ inputs.ref }}
+
+# Tags the chosen ref with `v<version>` (where version comes from
+# gradle/libs.versions.toml) and creates a GitHub Release that combines:
+#   1. The hand-written changelog at `changelogs/<version>.md`
+#   2. GitHub's auto-generated "What's Changed" section between the previous
+#      v-tag and this one.
+#
+# Typical flow:
+#   1. Bump `modo = "X.Y.Z"` in gradle/libs.versions.toml, commit, merge to dev.
+#   2. Publish to Maven Central via the `Publish` workflow (separate concern).
+#   3. Run this workflow with ref = dev (or release branch). Done.
+#
+# Pre-conditions checked at runtime:
+#   - `changelogs/<version>.md` exists.
+#   - Either the `v<version>` tag does not exist yet, or it exists but no
+#     GitHub release has been created for it yet (retry-friendly).
+#
+# Versions containing `-` (e.g. `0.12.0-rc1`) are marked as pre-release.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to release (branch, tag, or commit SHA)"
+        required: true
+        default: "dev"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Resolve version and changelog
+        id: meta
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=$(awk -F'"' '/^modo[[:space:]]*=/ {print $2; exit}' gradle/libs.versions.toml)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not read 'modo' version from gradle/libs.versions.toml"
+            exit 1
+          fi
+          TAG="v$VERSION"
+          CHANGELOG="changelogs/${VERSION}.md"
+          if [ ! -f "$CHANGELOG" ]; then
+            echo "::error::Changelog not found: $CHANGELOG"
+            exit 1
+          fi
+
+          # Retry-friendly: allow re-run if tag was created but release wasn't.
+          # Fail only if both already exist.
+          if git rev-parse "refs/tags/$TAG" >/dev/null 2>&1; then
+            if gh release view "$TAG" >/dev/null 2>&1; then
+              echo "::error::Release $TAG already exists. Bump version in libs.versions.toml."
+              exit 1
+            fi
+            CREATE_TAG=false
+            echo "Tag $TAG already exists; will reuse and only create the release."
+          else
+            CREATE_TAG=true
+          fi
+
+          {
+            echo "tag=$TAG"
+            echo "version=$VERSION"
+            echo "changelog=$CHANGELOG"
+            echo "create_tag=$CREATE_TAG"
+            if [[ "$VERSION" == *-* ]]; then
+              echo "prerelease=true"
+            else
+              echo "prerelease=false"
+            fi
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        if: steps.meta.outputs.create_tag == 'true'
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          # Identity recommended by actions/checkout README:
+          # https://github.com/actions/checkout#push-a-commit-using-the-built-in-token
+          # Email format is {user.id}+{user.login}@users.noreply.github.com.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "$TAG"
+          git push origin "$TAG"
+
+      - name: Resolve previous tag
+        id: prev
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          PREV=$(git tag --list 'v*' --sort=-v:refname \
+            | grep -v "^${TAG}$" \
+            | head -n 1 || true)
+          echo "tag=$PREV" >> "$GITHUB_OUTPUT"
+
+      - name: Compose release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          PREV: ${{ steps.prev.outputs.tag }}
+          CHANGELOG: ${{ steps.meta.outputs.changelog }}
+        run: |
+          if [ -n "$PREV" ]; then
+            AUTO=$(gh api -X POST "/repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+              -f tag_name="$TAG" \
+              -f previous_tag_name="$PREV" \
+              -q .body)
+          else
+            AUTO=$(gh api -X POST "/repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+              -f tag_name="$TAG" \
+              -q .body)
+          fi
+          {
+            cat "$CHANGELOG"
+            echo
+            echo "---"
+            echo
+            echo "$AUTO"
+          } > /tmp/notes.md
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          PRERELEASE: ${{ steps.meta.outputs.prerelease }}
+        run: |
+          ARGS=( --title "$TAG" --notes-file /tmp/notes.md )
+          if [ "$PRERELEASE" = "true" ]; then
+            ARGS+=( --prerelease )
+          fi
+          gh release create "$TAG" "${ARGS[@]}"
+          echo "Released **$TAG**" >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,16 @@ formatting in the file you're editing.
 - Breaking API changes on public types (`NavigationContainer`, `Screen`, `NavModel`, etc.) require a deliberate decision — surface in a task doc (see
   *Non-trivial work* below) before implementing.
 
+## Releases & changelogs
+
+Per-release notes live at `changelogs/<version>.md` (e.g. `changelogs/0.12.0.md`). The `GitHub Release` workflow expects this exact path; a missing file fails the release.
+
+**Append entries as you work, not at release time.** When you make a user-visible change — new/changed public API, deprecation, behavior change, notable bug fix, sample-app feature — add a bullet to the in-progress changelog in the same task. Defer-and-batch produces "what changed since last release? let me grep git log" archaeology; we explicitly avoid that.
+
+The in-progress changelog is `changelogs/<version>.md` where `<version>` is whatever `modo = "<version>"` currently is in `gradle/libs.versions.toml`. If that file doesn't exist yet, create it. If that version is already released (file exists *and* the version is on Maven Central), the change belongs to the *next* release — bump `modo` in `libs.versions.toml` and create a fresh changelog. Match the section structure (`## Architecture refactor`, `## API changes`, `## Deprecations`, `## Sample app changes`, `## Test changes`, `## Repo meta`) of the previous release file; omit sections that don't apply.
+
+To cut a release: ensure `changelogs/<version>.md` is complete, then run the `Publish` and `GitHub Release` workflows. See `PUBLISHING.md` for the full procedure.
+
 ## Non-trivial work
 
 For multi-step tasks (refactors, architectural investigations, work likely to span sessions), we use a task-folder workflow — see the **task-workflow

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 composeWheelPicker = "1.0.0-beta05"
 leakcanaryAndroid = "2.14"
-modo = "0.12.0-rc1"
+modo = "0.12.0"
 #noinspection AndroidGradlePluginVersion
 androidGradlePlugin = "8.13.2"
 nexusPublish = "2.0.0"


### PR DESCRIPTION
## GitHub Release workflow

Adds `.github/workflows/github-release.yml`: a `workflow_dispatch`-only job that

- reads the current version from `gradle/libs.versions.toml`,
- creates and pushes a `v<version>` tag on the chosen ref (default `dev`),
- composes release notes from `changelogs/<version>.md` plus GitHub's auto-generated "What's Changed",
- creates the GitHub Release (marking pre-releases by detecting `-` in the version).

Retry-friendly: if the tag exists but no Release does, the job reuses the tag and only creates the Release. If a Release already exists for the tag, it fails so you bump the version first.

The git identity for tag push is `github-actions[bot]`, as recommended by the [`actions/checkout` README](https://github.com/actions/checkout#push-a-commit-using-the-built-in-token).

## Version bump

`modo = "0.12.0"` — to publish the final 0.12.0 (the 0.12.0-rc1 build was the smoke test of the new CI publish flow).

## Agent docs

Adds a `Releases & changelogs` section to `AGENTS.md` (and therefore `CLAUDE.md`, which is a symlink) documenting:

- the `changelogs/<version>.md` path the new workflow depends on,
- the expectation to append entries as work happens, not at release time,
- the section structure (`## API changes`, `## Deprecations`, …) to mirror.