### PR TITLE
Drop What's Changed tail from changelog files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,8 @@ Per-release notes live at `changelogs/<version>.md` (e.g. `changelogs/0.12.0.md`
 
 The in-progress changelog is `changelogs/<version>.md` where `<version>` is whatever `modo = "<version>"` currently is in `gradle/libs.versions.toml`. If that file doesn't exist yet, create it. If that version is already released (file exists *and* the version is on Maven Central), the change belongs to the *next* release — bump `modo` in `libs.versions.toml` and create a fresh changelog. Match the section structure (`## Architecture refactor`, `## API changes`, `## Deprecations`, `## Sample app changes`, `## Test changes`, `## Repo meta`) of the previous release file; omit sections that don't apply.
 
+Do **not** include a trailing `## What's Changed` / `**Full Changelog**` block in `changelogs/<version>.md` — the `GitHub Release` workflow appends GitHub's auto-generated equivalent. Including one in the file produces a duplicate on the release page.
+
 To cut a release: ensure `changelogs/<version>.md` is complete, then run the `Publish` and `GitHub Release` workflows. See `PUBLISHING.md` for the full procedure.
 
 ## Non-trivial work

--- a/changelogs/0.12.0.md
+++ b/changelogs/0.12.0.md
@@ -92,11 +92,3 @@ The previous action-based / hot-flow API is retained as deprecated bindings so e
 
 - Add `AGENTS.md` and `CLAUDE.md` for AI-agent orientation.
 - Add `.claude/skills/task-workflow/SKILL.md` for the task-folder workflow.
-
----
-
-## What's Changed
-
-* Architecture refactor: decouple NavModel, renderer, and reducer pipeline by @ikarenkov in https://github.com/ikarenkov/Modo/pull/78
-
-**Full Changelog**: https://github.com/ikarenkov/Modo/compare/v0.11.0...v0.12.0


### PR DESCRIPTION
## Fix

Drop the trailing `## What's Changed` block from `changelogs/0.12.0.md`. The `GitHub Release` workflow appends GitHub's auto-generated What's Changed when it creates the release; keeping one in the changelog file produced a duplicate visible on the [v0.12.0 release page](https://github.com/ikarenkov/Modo/releases/tag/v0.12.0).

The existing v0.12.0 release body on GitHub will be cleaned up via `gh release edit` independently of this PR.

## Agent docs

Document the rule in `AGENTS.md` so future changelog files don't bring the block back.