### PR TITLE
Remove leftover AI preamble lines from docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,10 @@ formatting in the file you're editing.
 - Breaking API changes on public types (`NavigationContainer`, `Screen`, `NavModel`, etc.) require a deliberate decision — surface in a task doc (see
   *Non-trivial work* below) before implementing.
 
+## Commit messages
+
+Keep them concise: state what was done. Add a line of detail only when *why* isn't obvious from the change itself — skip the explanation for self-evident edits.
+
 ## Releases & changelogs
 
 Per-release notes live at `changelogs/<version>.md` (e.g. `changelogs/0.12.0.md`). The `GitHub Release` workflow expects this exact path; a missing file fails the release.

--- a/Writerside/topics/QuickStartGuide.md
+++ b/Writerside/topics/QuickStartGuide.md
@@ -1,5 +1,3 @@
-Here's the improved version of your documentation text:
-
 # Quick Start Guide
 
 <list columns="2">

--- a/Writerside/topics/Screen-effects.md
+++ b/Writerside/topics/Screen-effects.md
@@ -1,5 +1,3 @@
-Here’s the improved version of your documentation text:
-
 # Screen Effects
 
 Modo provides a [set of side effects](%github_code_url%modo-compose/src/main/java/com/github/terrakok/modo/lifecycle) that are similar to


### PR DESCRIPTION
Drop the "Here's the improved version of your documentation text:" line that leaked into QuickStartGuide.md and Screen-effects.md. Also adds a brief commit-message convention to AGENTS.md.